### PR TITLE
[3주차] 설지은/[feat] 블로그 CRUD 구현

### DIFF
--- a/blog_manage/blog_manage/build.gradle
+++ b/blog_manage/blog_manage/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.6'
+	id 'org.springframework.boot' version '3.3.0'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -19,6 +19,9 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/common/dto/ApiResponse.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/common/dto/ApiResponse.java
@@ -1,0 +1,33 @@
+package com.leets.backend.blog.common.dto;
+
+public class ApiResponse<T> {
+    private final boolean success;
+    private final T data;
+    private final ErrorResponse error;
+
+    private ApiResponse(boolean success, T data, ErrorResponse error) {
+        this.success = success;
+        this.data = data;
+        this.error = error;
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<T> error(ErrorResponse error) {
+        return new ApiResponse<>(false, null, error);
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public ErrorResponse getError() {
+        return error;
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/common/dto/ErrorResponse.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/common/dto/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.leets.backend.blog.common.dto;
+
+import java.time.LocalDateTime;
+
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.leets.backend.blog.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // CSRF 보호 비활성화 (API 서버에서는 보통 비활성화)
+                .authorizeHttpRequests(authorize -> authorize
+                        // Swagger UI 및 API 문서 경로에 대한 접근 허용
+                        .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .anyRequest().permitAll() // 모든 요청을 우선 허용 (추후 API별로 권한 설정 필요)
+                );
+
+        return http.build();
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/controller/AuthController.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/controller/AuthController.java
@@ -1,0 +1,37 @@
+package com.leets.backend.blog.controller;
+
+import com.leets.backend.blog.common.dto.ApiResponse;
+import com.leets.backend.blog.dto.UserLoginRequest;
+import com.leets.backend.blog.dto.UserSignUpRequest;
+import com.leets.backend.blog.dto.UserResponse;
+import com.leets.backend.blog.entity.User;
+import com.leets.backend.blog.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<UserResponse>> signUp(@Valid @RequestBody UserSignUpRequest request) {
+        User newUser = authService.signUp(request);
+        UserResponse userResponse = new UserResponse(newUser);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(userResponse));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<UserResponse>> login(@Valid @RequestBody UserLoginRequest request) {
+        User user = authService.login(request);
+        UserResponse userResponse = new UserResponse(user);
+        return ResponseEntity.ok(ApiResponse.success(userResponse));
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/controller/PostController.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/controller/PostController.java
@@ -1,33 +1,63 @@
 package com.leets.backend.blog.controller;
 
+import com.leets.backend.blog.common.dto.ApiResponse;
+import com.leets.backend.blog.entity.Post;
+import com.leets.backend.blog.dto.PostCreateRequest;
+import com.leets.backend.blog.dto.PostResponse;
+import com.leets.backend.blog.dto.PostUpdateRequest;
 import com.leets.backend.blog.service.PostService;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
-@Controller     // 요청/응답 처리 (웹 요청을 받아 Service 호출)
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/posts")
 public class PostController {
+
     private final PostService postService;
 
-    public PostController(PostService postService) {        // Service 계층 주입(의존성 주입)
+    public PostController(PostService postService) {
         this.postService = postService;
     }
 
-    @GetMapping("/posts")       // 게시글 목록 조회(Read)
-    public String listPosts(Model model) {
-        return "posts";
+    @PostMapping
+    public ResponseEntity<ApiResponse<PostResponse>> createPost(@Valid @RequestBody PostCreateRequest request) {
+        Post post = postService.createPost(request);
+        PostResponse response = new PostResponse(post);
+        return ResponseEntity.created(URI.create("/api/posts/" + post.getPostId()))
+                .body(ApiResponse.success(response));
     }
 
-    @GetMapping("/post/new")        // 새 게시글 작성 폼
-    public String newPostForm() {
-        return "new-post";
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PostResponse>>> getAllPosts() {
+        List<Post> posts = postService.findAllPosts();
+        List<PostResponse> responses = posts.stream()
+                .map(PostResponse::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(responses));
     }
 
-    @PostMapping("/posts")       // 새 게시글 생성(Create)
-    public String createPost(@RequestParam("title") String title,
-                             @RequestParam("content") String content) {
-        return "redirect:/posts";
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<PostResponse>> getPostById(@PathVariable Long id) {
+        Post post = postService.findPostById(id);
+        PostResponse response = new PostResponse(post);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<PostResponse>> updatePost(@PathVariable Long id, @Valid @RequestBody PostUpdateRequest request) {
+        Post post = postService.updatePost(id, request);
+        PostResponse response = new PostResponse(post);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long id) {
+        postService.deletePost(id);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/controller/UserController.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.leets.backend.blog.controller;
+
+import com.leets.backend.blog.common.dto.ApiResponse;
+import com.leets.backend.blog.dto.UserResponse;
+import com.leets.backend.blog.dto.UserUpdateRequest;
+import com.leets.backend.blog.entity.User;
+import com.leets.backend.blog.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<UserResponse>> getUserById(@PathVariable Long id) {
+        User user = userService.getUserById(id);
+        UserResponse userResponse = new UserResponse(user);
+        return ResponseEntity.ok(ApiResponse.success(userResponse));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<UserResponse>> updateUser(@PathVariable Long id, @Valid @RequestBody UserUpdateRequest request) {
+        // TODO: 현재 로그인한 사용자와 id가 일치하는지 확인하는 로직 필요
+        User updatedUser = userService.updateUser(id, request);
+        UserResponse userResponse = new UserResponse(updatedUser);
+        return ResponseEntity.ok(ApiResponse.success(userResponse));
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/PostCreateRequest.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/PostCreateRequest.java
@@ -1,0 +1,21 @@
+package com.leets.backend.blog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class PostCreateRequest {
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 100, message = "제목은 100자를 넘을 수 없습니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/PostResponse.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/PostResponse.java
@@ -1,0 +1,41 @@
+package com.leets.backend.blog.dto;
+
+import com.leets.backend.blog.entity.Post;
+
+import java.time.LocalDateTime;
+
+public class PostResponse {
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public PostResponse(Post post) {
+        this.id = post.getPostId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.createdAt = post.getCreatedAt();
+        this.updatedAt = post.getUpdatedAt();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/PostUpdateRequest.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/PostUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.leets.backend.blog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class PostUpdateRequest {
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 100, message = "제목은 100자를 넘을 수 없습니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/UserLoginRequest.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/UserLoginRequest.java
@@ -1,0 +1,22 @@
+package com.leets.backend.blog.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class UserLoginRequest {
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+
+    // Getters
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/UserResponse.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/UserResponse.java
@@ -1,0 +1,48 @@
+package com.leets.backend.blog.dto;
+
+import com.leets.backend.blog.entity.User;
+
+import java.time.LocalDateTime;
+
+public class UserResponse {
+    private final Long id;
+    private final String email;
+    private final String nickname;
+    private final String profileUrl;
+    private final String loginType;
+    private final LocalDateTime createdAt;
+
+    public UserResponse(User user) {
+        this.id = user.getUserId();
+        this.email = user.getEmail();
+        this.nickname = user.getNickname();
+        this.profileUrl = user.getProfileUrl();
+        this.loginType = user.getLoginType();
+        this.createdAt = user.getCreatedAt();
+    }
+
+    // Getters
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getProfileUrl() {
+        return profileUrl;
+    }
+
+    public String getLoginType() {
+        return loginType;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/UserSignUpRequest.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/UserSignUpRequest.java
@@ -1,0 +1,32 @@
+package com.leets.backend.blog.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class UserSignUpRequest {
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
+    private String password;
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하이어야 합니다.")
+    private String nickname;
+
+    // Getter
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/UserUpdateRequest.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/dto/UserUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.leets.backend.blog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class UserUpdateRequest {
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하이어야 합니다.")
+    private String nickname;
+
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
+    private String password;
+
+    private String profileUrl; // 프로필 사진 URL은 필수가 아님
+
+    // Getters
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getProfileUrl() {
+        return profileUrl;
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/entity/Comment.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/entity/Comment.java
@@ -1,4 +1,4 @@
-package com.leets.backend.blog.domain;
+package com.leets.backend.blog.entity;
 
 import jakarta.persistence.*;
 

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/entity/Post.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/entity/Post.java
@@ -1,7 +1,7 @@
-package com.leets.backend.blog.domain;
+package com.leets.backend.blog.entity;
 
 import jakarta.persistence.*;
-import java.time.LocalDate;
+
 import java.time.LocalDateTime;
 
 @Entity
@@ -28,6 +28,20 @@ public class Post {
     private LocalDateTime updatedAt;
 
     public Post() {}
+
+    public Post(User user, String title, String content) {
+        this.user = user;
+        this.title = title;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+        this.updatedAt = LocalDateTime.now();
+    }
 
     // Getter (Lombok 금지)
     public Long getPostId() { return postId; }

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/entity/PostImage.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/entity/PostImage.java
@@ -1,4 +1,4 @@
-package com.leets.backend.blog.domain;
+package com.leets.backend.blog.entity;
 
 import jakarta.persistence.*;
 

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/entity/User.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/entity/User.java
@@ -1,4 +1,4 @@
-package com.leets.backend.blog.domain;
+package com.leets.backend.blog.entity;
 
 import jakarta.persistence.*;
 
@@ -48,6 +48,16 @@ public class User{
 
     public User() {}
 
+    // 회원가입 시 사용될 생성자
+    public User(String email, String password, String nickname, String loginType) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.loginType = loginType;
+        this.createdAt = LocalDateTime.now(); // 생성 시점 자동 설정
+        this.updatedAt = LocalDateTime.now(); // 업데이트 시점 자동 설정
+    }
+
     // Getter (Lombok 금지)
     public Long getUserId() { return userId; }
     public String getName() { return name; }
@@ -55,11 +65,41 @@ public class User{
     public String getPassword() { return password; }
     public String getNickname() { return nickname; }
     public LocalDate getBirthDate() { return birthDate; }
-    public String getIntroduction() { return intro; }
+    public String getIntro() { return intro; }
     public String getProfileUrl() { return profileUrl; }
     public String getLoginType() { return loginType; }
     public String getKakaoId() { return kakaoId; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
 
+    // Setters (필요한 경우에만 추가)
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void setProfileUrl(String profileUrl) {
+        this.profileUrl = profileUrl;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    // 사용자 정보 업데이트 메서드
+    public void update(String nickname, String password, String profileUrl, LocalDateTime updatedAt) {
+        if (nickname != null && !nickname.isEmpty()) {
+            this.nickname = nickname;
+        }
+        if (password != null && !password.isEmpty()) {
+            this.password = password;
+        }
+        if (profileUrl != null) {
+            this.profileUrl = profileUrl;
+        }
+        this.updatedAt = updatedAt;
+    }
 }

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/BadCredentialsException.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/BadCredentialsException.java
@@ -1,0 +1,15 @@
+package com.leets.backend.blog.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED) // HTTP 401 Unauthorized
+public class BadCredentialsException extends RuntimeException {
+    public BadCredentialsException() {
+        super("이메일 또는 비밀번호가 일치하지 않습니다.");
+    }
+
+    public BadCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/DuplicateEmailException.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/DuplicateEmailException.java
@@ -1,0 +1,15 @@
+package com.leets.backend.blog.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT) // HTTP 409 Conflict
+public class DuplicateEmailException extends RuntimeException {
+    public DuplicateEmailException() {
+        super("이미 등록된 이메일입니다.");
+    }
+
+    public DuplicateEmailException(String message) {
+        super(message);
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/DuplicateNicknameException.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/DuplicateNicknameException.java
@@ -1,0 +1,15 @@
+package com.leets.backend.blog.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT) // HTTP 409 Conflict
+public class DuplicateNicknameException extends RuntimeException {
+    public DuplicateNicknameException() {
+        super("이미 사용 중인 닉네임입니다.");
+    }
+
+    public DuplicateNicknameException(String message) {
+        super(message);
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/GlobalExceptionHandler.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/GlobalExceptionHandler.java
@@ -1,0 +1,81 @@
+package com.leets.backend.blog.exception;
+
+import com.leets.backend.blog.common.dto.ApiResponse;
+import com.leets.backend.blog.common.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // UserNotFoundException 처리
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ApiResponse<Object>> handleUserNotFound(UserNotFoundException e) {
+        ErrorResponse errorResponse = new ErrorResponse("USER_NOT_FOUND", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(errorResponse));
+    }
+
+    // BadCredentialsException 처리
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ApiResponse<Object>> handleBadCredentials(BadCredentialsException e) {
+        ErrorResponse errorResponse = new ErrorResponse("BAD_CREDENTIALS", e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error(errorResponse));
+    }
+
+    // DuplicateEmailException 처리
+    @ExceptionHandler(DuplicateEmailException.class)
+    public ResponseEntity<ApiResponse<Object>> handleDuplicateEmail(DuplicateEmailException e) {
+        ErrorResponse errorResponse = new ErrorResponse("DUPLICATE_EMAIL", e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(errorResponse));
+    }
+
+    // DuplicateNicknameException 처리
+    @ExceptionHandler(DuplicateNicknameException.class)
+    public ResponseEntity<ApiResponse<Object>> handleDuplicateNickname(DuplicateNicknameException e) {
+        ErrorResponse errorResponse = new ErrorResponse("DUPLICATE_NICKNAME", e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(errorResponse));
+    }
+
+    // PostNotFoundException 처리
+    @ExceptionHandler(PostNotFoundException.class)
+    public ResponseEntity<ApiResponse<Object>> handlePostNotFound(PostNotFoundException e) {
+        ErrorResponse errorResponse = new ErrorResponse("POST_NOT_FOUND", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(errorResponse));
+    }
+
+    // @Valid 유효성 검증 실패 시 발생하는 MethodArgumentNotValidException 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Object>> handleValidationExceptions(
+            MethodArgumentNotValidException e
+    ) {
+        // 첫 번째 유효성 검증 실패 메시지를 가져옵니다.
+        FieldError fieldError = e.getBindingResult().getFieldError();
+        String errorMessage = (fieldError != null) ? fieldError.getDefaultMessage() : "입력값이 올바르지 않습니다.";
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                "INVALID_INPUT",
+                errorMessage
+         );
+        return ResponseEntity.badRequest().body(ApiResponse.error(errorResponse));
+    }
+
+    // 예상치 못한 모든 예외 처리 (디버깅을 위해 잠시 주석 처리)
+//    @ExceptionHandler(Exception.class)
+//    public ResponseEntity<ApiResponse<Object>> handleAllExceptions(Exception e) {
+//        // 에러 로그를 콘솔에 출력합니다.
+//        e.printStackTrace();
+//
+//        ErrorResponse errorResponse = new ErrorResponse("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
+//        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+//                .body(ApiResponse.error(errorResponse));
+//    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/PostNotFoundException.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/PostNotFoundException.java
@@ -1,0 +1,11 @@
+package com.leets.backend.blog.exception;
+
+public class PostNotFoundException extends RuntimeException {
+    public PostNotFoundException() {
+        super("게시글을 찾을 수 없습니다.");
+    }
+
+    public PostNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/UserNotFoundException.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/exception/UserNotFoundException.java
@@ -1,0 +1,15 @@
+package com.leets.backend.blog.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND) // HTTP 404 Not Found
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException() {
+        super("사용자를 찾을 수 없습니다.");
+    }
+
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/repository/CommentRepository.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/repository/CommentRepository.java
@@ -1,6 +1,6 @@
 package com.leets.backend.blog.repository;
 
-import com.leets.backend.blog.domain.Comment;
+import com.leets.backend.blog.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/repository/PostImageRepository.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/repository/PostImageRepository.java
@@ -1,6 +1,6 @@
 package com.leets.backend.blog.repository;
 
-import com.leets.backend.blog.domain.PostImage;
+import com.leets.backend.blog.entity.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/repository/PostRepository.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/repository/PostRepository.java
@@ -1,14 +1,8 @@
 package com.leets.backend.blog.repository;
 
-import com.leets.backend.blog.domain.Post;
+import com.leets.backend.blog.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/repository/UserRepository.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package com.leets.backend.blog.repository;
 
-import com.leets.backend.blog.domain.User;
+import com.leets.backend.blog.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByNickname(String nickname);
 }

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/service/AuthService.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/service/AuthService.java
@@ -1,0 +1,67 @@
+package com.leets.backend.blog.service;
+
+import com.leets.backend.blog.dto.UserLoginRequest;
+import com.leets.backend.blog.dto.UserSignUpRequest;
+import com.leets.backend.blog.entity.User;
+import com.leets.backend.blog.exception.BadCredentialsException;
+import com.leets.backend.blog.exception.DuplicateEmailException;
+import com.leets.backend.blog.exception.DuplicateNicknameException;
+import com.leets.backend.blog.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    public User signUp(UserSignUpRequest request) {
+        // 1. 이메일 중복 확인
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new DuplicateEmailException();
+        }
+
+        // 2. 닉네임 중복 확인
+        if (userRepository.findByNickname(request.getNickname()).isPresent()) {
+            throw new DuplicateNicknameException();
+        }
+
+        // 3. 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        // 4. User 엔티티 생성 및 저장
+        User newUser = new User(
+                request.getEmail(),
+                encodedPassword,
+                request.getNickname(),
+                "EMAIL" // 로그인 타입은 일단 EMAIL로 고정
+        );
+
+        return userRepository.save(newUser);
+    }
+
+    @Transactional(readOnly = true)
+    public User login(UserLoginRequest request) {
+        // 1. 이메일로 사용자 찾기
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(BadCredentialsException::new);
+
+        // 2. 비밀번호 일치 여부 확인
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BadCredentialsException();
+        }
+
+        return user;
+    }
+}

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/service/PostService.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/service/PostService.java
@@ -1,9 +1,64 @@
 package com.leets.backend.blog.service;
 
+import com.leets.backend.blog.entity.Post;
+import com.leets.backend.blog.entity.User;
+import com.leets.backend.blog.dto.PostCreateRequest;
+import com.leets.backend.blog.dto.PostUpdateRequest;
+import com.leets.backend.blog.exception.PostNotFoundException;
+import com.leets.backend.blog.repository.PostRepository;
+import com.leets.backend.blog.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 
-@Service        // 비즈니스 로직 담당, Repository 호출
+@Service
+@Transactional(readOnly = true)     // 이 클래스의 메서드들은 기본적으로 데이터를 읽기만 함
 public class PostService {
 
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    public PostService(PostRepository postRepository, UserRepository userRepository) {
+        this.postRepository = postRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional      // 해당 메서드는 readOnly가 아님을 알려줌, 메서드 실패 시 Rollback
+    public Post createPost(PostCreateRequest request) {
+        // ToDo: 인증 기능 추가 후 실제 사용자 정보로 변경해야 함
+        // 임시로 ID가 1인 사용자가 모든 작업 수행한다고 가정
+        User temporaryUser = userRepository.findById(1L).orElseThrow(() -> new RuntimeException("임시 사용자를 찾을 수 없습니다."));
+
+        Post post = new Post(temporaryUser, request.getTitle(), request.getContent());
+        return postRepository.save(post);
+    }
+
+    public List<Post> findAllPosts() {
+        return postRepository.findAll();
+    }
+
+    public Post findPostById(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(PostNotFoundException::new);
+    }
+
+    @Transactional
+    public Post updatePost(Long postId, PostUpdateRequest request) {
+        Post post = findPostById(postId);
+
+        // TODO: 사용자 인증 기능 추가 후, 게시글 작성자 본인인지 확인하는 로직 필요
+
+        post.update(request.getTitle(), request.getContent());
+        return post;
+    }
+
+    @Transactional
+    public void deletePost(Long postId) {
+        Post post = findPostById(postId);
+
+        // TODO: 사용자 인증 기능 추가 후, 게시글 작성자 본인인지 확인하는 로직 필요
+
+        postRepository.delete(post);
+    }
 }

--- a/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/service/UserService.java
+++ b/blog_manage/blog_manage/src/main/java/com/leets/backend/blog/service/UserService.java
@@ -1,0 +1,59 @@
+package com.leets.backend.blog.service;
+
+import com.leets.backend.blog.dto.UserUpdateRequest;
+import com.leets.backend.blog.entity.User;
+import com.leets.backend.blog.exception.DuplicateNicknameException;
+import com.leets.backend.blog.exception.UserNotFoundException;
+import com.leets.backend.blog.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    @Transactional
+    public User updateUser(Long userId, UserUpdateRequest request) {
+        User user = getUserById(userId);
+
+        // TODO: 현재 로그인한 사용자와 userId가 일치하는지 확인하는 로직 필요
+
+        // 닉네임 중복 확인 (변경 요청이 있고, 기존 닉네임과 다를 경우)
+        if (request.getNickname() != null && !request.getNickname().isEmpty() && !user.getNickname().equals(request.getNickname())) {
+            if (userRepository.findByNickname(request.getNickname()).isPresent()) {
+                throw new DuplicateNicknameException();
+            }
+        }
+
+        // 비밀번호 암호화 (변경 요청이 있을 경우)
+        String encodedPassword = null;
+        if (request.getPassword() != null && !request.getPassword().isEmpty()) {
+            encodedPassword = passwordEncoder.encode(request.getPassword());
+        }
+
+        user.update(
+                request.getNickname(),
+                encodedPassword,
+                request.getProfileUrl(),
+                LocalDateTime.now()
+        );
+
+        return userRepository.save(user);
+    }
+}

--- a/blog_manage/blog_manage/src/main/resources/application.yml
+++ b/blog_manage/blog_manage/src/main/resources/application.yml
@@ -2,13 +2,18 @@ spring:
   application:
     name: blog
   datasource:
-    url: jdbc:mysql://localhost:3306/blog_db?serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3306/blog_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useUnicode=true
     username: root
     password: 8637
   jpa:
     hibernate:
-      ddl-auto: update   # 개발 단계에서는 update / 운영은 validate 권장
+      ddl-auto: create   # 실행마다 DB 테이블 재생성
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
     show-sql: true
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always       # 항상 data.sql 실행

--- a/blog_manage/blog_manage/src/main/resources/data.sql
+++ b/blog_manage/blog_manage/src/main/resources/data.sql
@@ -1,0 +1,8 @@
+INSERT INTO `user` (`USER_ID`, `NAME`, `EMAIL`, `PASSWORD`, `NICKNAME`, `BIRTH_DATE`, `INTRO`, `PROFILE_URL`, `LOGIN_TYPE`, `KAKAO_ID`, `CREATED_AT`, `UPDATED_AT`)
+VALUES (1, '임시사용자', 'test@example.com', 'test1234', '임시닉네임', '2000-01-01', '자기소개입니다.', null, 'EMAIL', null, NOW(), NOW());
+
+INSERT INTO `post` (`USER_ID`, `TITLE`, `CONTENT`, `CREATED_AT`, `UPDATED_AT`) VALUES (1, '첫 번째 게시글', '첫 번째 게시글 내용입니다.', NOW(), NOW());
+INSERT INTO `post` (`USER_ID`, `TITLE`, `CONTENT`, `CREATED_AT`, `UPDATED_AT`) VALUES (1, '두 번째 게시글', '두 번째 게시글 내용입니다. 테스트 중입니다.', NOW(), NOW());
+INSERT INTO `post` (`USER_ID`, `TITLE`, `CONTENT`, `CREATED_AT`, `UPDATED_AT`) VALUES (1, '세 번째 게시글', '세 번째 게시글 내용입니다. API가 잘 동작하네요.', NOW(), NOW());
+INSERT INTO `post` (`USER_ID`, `TITLE`, `CONTENT`, `CREATED_AT`, `UPDATED_AT`) VALUES (1, '네 번째 게시글', '네 번째 게시글 내용입니다. 더미 데이터 생성.', NOW(), NOW());
+INSERT INTO `post` (`USER_ID`, `TITLE`, `CONTENT`, `CREATED_AT`, `UPDATED_AT`) VALUES (1, '다섯 번째 게시글', '다섯 번째 게시글 내용입니다. 리스트 조회 테스트.', NOW(), NOW());


### PR DESCRIPTION
 ## 1. 무슨 이유로 코드를 변경했나요?

  기존 MVC 패턴의 게시물 API를 REST API 방식으로 전환하여 프론트엔드와 백엔드의 역할을 명확히 분리하고, 다양한 클라이언트(웹, 모바일)에 유연하게 대응할 수 있는 확장성 있는 구조를 구축하기 위함
 또한, 사용자 관리의 기본이 되는 회원가입 및 로그인 기능을 구현하여 서비스의 핵심 기능을 완성

  <br>

## 2. 어떤 위험이나 장애를 발견했나요?

   - 초기 Swagger 연동 문제: Spring Security 설정과 Swagger UI 경로 접근 권한 문제로 500 에러가 발생 
   -> `SecurityConfig`에서 Swagger 관련 경로를 `permitAll()`로 명시적으로 허용
   - 데이터베이스 한글 인코딩 문제: MySQL 데이터베이스 자체의 문자 체계가 UTF-8을 지원하지 않아 data.sql 실행 시 한글 데이터 저장에 실패
   -> `application.yml`의 JDBC URL에 `characterEncoding=UTF-8&useUnicode=true`를 추가하고, `blog_db` 데이터베이스 및 `user`, `post` 테이블의 문자 세트를 `utf8mb4`로 변경하는 SQL 명령어를 실행
   - JPA 엔티티 생명주기 문제: Post 엔티티 생성자에서 createdAt 필드를 초기화하지 않아 nullable=false 제약 조건 위반 에러가 발생 
   -> `Post` 엔티티의 생성자에서 `createdAt`과 `updatedAt` 필드를 `LocalDateTime.now()`로 직접 초기화하도록 수정
   - 디버깅 환경 문제: GlobalExceptionHandler의 로깅 누락 및 개발 환경에서 여러 애플리케이션 인스턴스 실행으로 인한 혼란 
   -> `GlobalExceptionHandler`의 `handleAllExceptions` 메서드에 `e.printStackTrace()`를 추가하여 콘솔에 에러 로그가 출력되도록 수정 +  `application.yml`에 `ddl-auto: create`와 `sql.init.mode: always`를 설정
   - 라이브러리 버전 충돌: build.gradle의 스프링 부트 버전 오타로 인해 NoSuchMethodError가 발생 
   -> `build.gradle`의 스프링 부트 버전을 `3.5.6`에서 안정적인 `3.3.0`으로 수정하여 라이브러리 호환성 문제를 해결

  <br>

## 3. 관련 스크린샷을 첨부해주세요.
GET: /api/posts/{id}
<img width="640" height="661" alt="스크린샷 2025-10-10 164917" src="https://github.com/user-attachments/assets/84d83ae6-2aee-4bf8-97ba-86e497790b47" />
PUT: /api/posts/{id}
<img width="656" height="727" alt="스크린샷 2025-10-10 164930" src="https://github.com/user-attachments/assets/5e63e2e2-9fd7-46ae-af41-0f6b539cfb0d" />
DELETE: /api/posts/{id}
<img width="638" height="578" alt="스크린샷 2025-10-10 164954" src="https://github.com/user-attachments/assets/97d5b7ad-470b-4696-aac9-6f5b855e5543" />
GET: /api/posts
<img width="630" height="844" alt="스크린샷 2025-10-10 165017" src="https://github.com/user-attachments/assets/ea2d961e-75a6-4814-84ab-747ece0e75c1" />
POST: /api/posts
<img width="647" height="742" alt="스크린샷 2025-10-10 165041" src="https://github.com/user-attachments/assets/bd35a53f-58fe-4ce9-b4af-30739683c87b" />
DB 위 실행 결과
<img width="1010" height="162" alt="스크린샷 2025-10-10 165057" src="https://github.com/user-attachments/assets/40b9f311-7509-4760-9066-3edc8a416030" />
POST: /api/auth/signup
<img width="643" height="760" alt="스크린샷 2025-10-10 165120" src="https://github.com/user-attachments/assets/ad94aace-bcd3-4ea7-83fd-2fdcea2b41d5" />
POST: /api/auth/login
<img width="644" height="745" alt="스크린샷 2025-10-10 165147" src="https://github.com/user-attachments/assets/33e87547-64b5-4827-9d29-482ed791c520" />
DB 위 실행 결과
<img width="1286" height="97" alt="스크린샷 2025-10-10 165203" src="https://github.com/user-attachments/assets/c3366e61-1341-45e7-8b68-d2033793248f" />
GET: /api/users/{id}
<img width="640" height="677" alt="스크린샷 2025-10-10 165234" src="https://github.com/user-attachments/assets/60b15731-34e4-4c3f-b6eb-e70532711697" />
PUT: /api/users/{id}
<img width="647" height="753" alt="스크린샷 2025-10-10 165359" src="https://github.com/user-attachments/assets/29b30d18-d567-4ac4-ab47-ec6b5054d569" />
DB 위 실행 결과
<img width="1288" height="58" alt="스크린샷 2025-10-10 165456" src="https://github.com/user-attachments/assets/9aa43a70-eac9-47e5-80e4-e35794e07ae0" />



  <br>

## 4. 완료 사항

   - 게시물 CRUD API 구현 (RESTful 원칙 준수)
   - 이메일 기반 회원가입 및 로그인 기능 구현
   - 사용자 정보 조회 및 수정 기능 구현
   - 요청/응답 DTO 분리 및 유효성 검증 적용
   - GlobalExceptionHandler 및 공통 응답 형식 적용
   - 스웨거(Swagger)를 통한 API 문서화 및 테스트 환경 구축

  <br>

## 5. 추가 사항

   - 현재까지 구현된 기능: 게시물 CRUD, 이메일 기반 회원가입 및 로그인, 사용자 정보 조회/수정.
   - 향후 확장 가능 기능: 카카오 OAuth 연동, 프로필 사진 업로드, 사용자별 권한 관리(인증/인가) 등.

  closed #49 
