### PR TITLE
[4주차] 성현준/[feat] 댓글기능 API 구현

### DIFF
--- a/blog_manage/build.gradle
+++ b/blog_manage/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.cyclonedx.bom' version '2.3.0'
 }
@@ -27,6 +27,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }
 
 tasks.named('test') {

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/controller/CommentController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/controller/CommentController.java
@@ -5,20 +5,21 @@ import com.leets.backend.blog_manage.dto.CommentCreateRequest;
 import com.leets.backend.blog_manage.dto.CommentResponse;
 import com.leets.backend.blog_manage.dto.CommentUpdateRequest;
 import com.leets.backend.blog_manage.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
+@Tag(name = "댓글 (Comment) API", description = "게시물에 대한 댓글 관련 API")
 @RestController
 @RequestMapping("/api") // /api 공통 경로
 public class CommentController {
 
     private final CommentService commentService;
 
-    @Autowired
     public CommentController(CommentService commentService) {
         this.commentService = commentService;
     }
@@ -27,6 +28,7 @@ public class CommentController {
      * 1. 댓글 생성
      * POST /api/posts/{postId}/comments
      */
+    @Operation(summary = "댓글 생성", description = "특정 게시물(postId)에 새로운 댓글을 등록합니다.")
     @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<CommentResponse>> createComment(
             @PathVariable Long postId,
@@ -43,6 +45,7 @@ public class CommentController {
      * 2. 특정 게시물 댓글 목록 조회 (요구사항: 로그인 없이 조회 가능)
      * GET /api/posts/{postId}/comments
      */
+    @Operation(summary = "댓글 목록 조회", description = "특정 게시물(postId)의 모든 댓글을 조회합니다.")
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<List<CommentResponse>>> getCommentsByPostId(
             @PathVariable Long postId) {
@@ -55,6 +58,7 @@ public class CommentController {
      * 3. 댓글 수정 (요구사항: 본인 댓글만 수정 가능)
      * PUT /api/comments/{commentId}
      */
+    @Operation(summary = "댓글 수정", description = "특정 ID의 댓글(commentId)을 수정합니다. (작성자 본인만 가능)")
     @PutMapping("/comments/{commentId}")
     public ResponseEntity<ApiResponse<CommentResponse>> updateComment(
             @PathVariable Long commentId,
@@ -68,6 +72,7 @@ public class CommentController {
      * 4. 댓글 삭제 (요구사항: 본인 댓글만 삭제 가능)
      * DELETE /api/comments/{commentId}
      */
+    @Operation(summary = "댓글 삭제", description = "특정 ID의 댓글(commentId)을 삭제합니다. (작성자 본인만 가능)")
     @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<ApiResponse<Object>> deleteComment(@PathVariable Long commentId) {
         commentService.deleteComment(commentId);

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/controller/CommentController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/controller/CommentController.java
@@ -1,0 +1,76 @@
+package com.leets.backend.blog_manage.controller;
+
+import com.leets.backend.blog_manage.common.ApiResponse;
+import com.leets.backend.blog_manage.dto.CommentCreateRequest;
+import com.leets.backend.blog_manage.dto.CommentResponse;
+import com.leets.backend.blog_manage.dto.CommentUpdateRequest;
+import com.leets.backend.blog_manage.service.CommentService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api") // /api 공통 경로
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Autowired
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    /**
+     * 1. 댓글 생성
+     * POST /api/posts/{postId}/comments
+     */
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateRequest request) {
+
+        CommentResponse commentResponse = commentService.createComment(postId, request);
+        return new ResponseEntity<>(
+                ApiResponse.success("댓글이 성공적으로 생성되었습니다.", commentResponse),
+                HttpStatus.CREATED
+        );
+    }
+
+    /**
+     * 2. 특정 게시물 댓글 목록 조회 (요구사항: 로그인 없이 조회 가능)
+     * GET /api/posts/{postId}/comments
+     */
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<List<CommentResponse>>> getCommentsByPostId(
+            @PathVariable Long postId) {
+
+        List<CommentResponse> comments = commentService.getCommentsByPostId(postId);
+        return ResponseEntity.ok(ApiResponse.success("댓글 목록 조회 성공", comments));
+    }
+
+    /**
+     * 3. 댓글 수정 (요구사항: 본인 댓글만 수정 가능)
+     * PUT /api/comments/{commentId}
+     */
+    @PutMapping("/comments/{commentId}")
+    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentUpdateRequest request) {
+
+        CommentResponse commentResponse = commentService.updateComment(commentId, request);
+        return ResponseEntity.ok(ApiResponse.success("댓글이 성공적으로 수정되었습니다.", commentResponse));
+    }
+
+    /**
+     * 4. 댓글 삭제 (요구사항: 본인 댓글만 삭제 가능)
+     * DELETE /api/comments/{commentId}
+     */
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<ApiResponse<Object>> deleteComment(@PathVariable Long commentId) {
+        commentService.deleteComment(commentId);
+        return ResponseEntity.ok(ApiResponse.success("댓글이 성공적으로 삭제되었습니다.", null));
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/controller/PostController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/controller/PostController.java
@@ -7,8 +7,9 @@ import com.leets.backend.blog_manage.dto.PostListResponse;
 import com.leets.backend.blog_manage.dto.PostUpdateRequest;
 import com.leets.backend.blog_manage.entity.Post;
 import com.leets.backend.blog_manage.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -16,17 +17,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "게시물 (Post) API", description = "게시물 CRUD 관련 API")
 @RestController
 @RequestMapping("/api/posts")
 public class PostController {
 
     private final PostService postService;
 
-    @Autowired
     public PostController(PostService postService) {
         this.postService = postService;
     }
 
+    @Operation(summary = "게시물 생성", description = "새로운 게시물을 등록합니다.")
     @PostMapping
     public ResponseEntity<ApiResponse<PostDetailResponse>> createPost(@Valid @RequestBody PostCreateRequest request) {
         Post savedPost = postService.createPost(request);
@@ -36,18 +38,21 @@ public class PostController {
         );
     }
 
+    @Operation(summary = "게시물 목록 조회", description = "게시물 목록을 페이지별로 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<Page<PostListResponse>>> listPosts(@PageableDefault(size = 10) Pageable pageable) {
         Page<PostListResponse> posts = postService.getAllPosts(pageable);
         return ResponseEntity.ok(ApiResponse.success("게시물 목록 조회 성공", posts));
     }
 
+    @Operation(summary = "게시물 상세 조회", description = "특정 ID의 게시물을 상세 조회합니다.")
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(@PathVariable Long id) {
         Post post = postService.findPostById(id);
         return ResponseEntity.ok(ApiResponse.success("게시물 상세 조회 성공", new PostDetailResponse(post)));
     }
 
+    @Operation(summary = "게시물 수정", description = "특정 ID의 게시물을 수정합니다. (작성자 본인만 가능)")
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponse<PostDetailResponse>> updatePost(@PathVariable Long id, @Valid @RequestBody PostUpdateRequest request) {
         postService.updatePost(id, request);
@@ -55,6 +60,7 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.success("게시물이 성공적으로 수정되었습니다.", new PostDetailResponse(updatedPost)));
     }
 
+    @Operation(summary = "게시물 삭제", description = "특정 ID의 게시물을 삭제합니다. (작성자 본인만 가능)")
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Object>> deletePost(@PathVariable Long id) {
         postService.deletePost(id);

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/CommentCreateRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/CommentCreateRequest.java
@@ -1,0 +1,15 @@
+package com.leets.backend.blog_manage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class CommentCreateRequest {
+    @NotBlank(message = "댓글 내용을 입력해주세요")
+    private String content;
+
+    public String getContent() {
+        return content;
+    }
+
+    // Setter 추가 가능
+    // public void setContent(String content) { this.content = content; }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/CommentResponse.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/CommentResponse.java
@@ -1,0 +1,27 @@
+package com.leets.backend.blog_manage.dto;
+
+import com.leets.backend.blog_manage.entity.Comment;
+import java.time.LocalDateTime;
+
+public class CommentResponse {
+    private final Long id;
+    private final String content;
+    private final String authorNickname;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public CommentResponse(Comment comment) {
+        this.id = comment.getId();
+        this.content = comment.getContent();
+        this.authorNickname = comment.getUser().getNickname();
+        this.createdAt = comment.getCreatedAt();
+        this.updatedAt = comment.getUpdatedAt();
+    }
+
+    // --- Getters ---
+    public Long getId() { return id; }
+    public String getContent() { return content; }
+    public String getAuthorNickname() { return authorNickname; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/CommentUpdateRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/CommentUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.leets.backend.blog_manage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class CommentUpdateRequest {
+    @NotBlank(message = "댓글 내용을 입력해주세요")
+    private String content;
+
+    public String getContent() {
+        return content;
+    }
+
+    // public void setContent(String content) { this.content = content; }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/entity/Comment.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/entity/Comment.java
@@ -29,6 +29,19 @@ public class Comment {
 
     public Comment() {}
 
+    public Comment(String content, User user, Post post) {
+        this.content = content;
+        this.user = user;
+        this.post = post;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void update(String content) {
+        this.content = content;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
     // --- Getters ---
     public Long getId() { return id; }
     public String getContent() { return content; }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/exception/ErrorCode.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다.");
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/service/CommentService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/service/CommentService.java
@@ -1,0 +1,112 @@
+package com.leets.backend.blog_manage.service;
+
+import com.leets.backend.blog_manage.dto.CommentCreateRequest;
+import com.leets.backend.blog_manage.dto.CommentResponse;
+import com.leets.backend.blog_manage.dto.CommentUpdateRequest;
+import com.leets.backend.blog_manage.entity.Comment;
+import com.leets.backend.blog_manage.entity.Post;
+import com.leets.backend.blog_manage.entity.User;
+import com.leets.backend.blog_manage.exception.CustomException;
+import com.leets.backend.blog_manage.exception.ErrorCode;
+import com.leets.backend.blog_manage.repository.CommentRepository;
+import com.leets.backend.blog_manage.repository.PostRepository;
+import com.leets.backend.blog_manage.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public CommentService(CommentRepository commentRepository, PostRepository postRepository, UserRepository userRepository) {
+        this.commentRepository = commentRepository;
+        this.postRepository = postRepository;
+        this.userRepository = userRepository;
+    }
+
+
+    // PostService와 동일한 임시 사용자 조회 로직
+
+    private User getTemporaryUser() {
+        // 요구사항: 로그인 기능 구현 전이므로 임시 사용자(ID 1L) 사용
+        return userRepository.findById(1L)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    // ID로 게시물 조회 (공용)
+    private Post findPostById(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    // ID로 댓글 조회 (공용)
+    private Comment findCommentById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+    }
+
+    // 1. 댓글 생성
+    @Transactional
+    public CommentResponse createComment(Long postId, CommentCreateRequest request) {
+        User user = getTemporaryUser(); // 임시 유저 사용
+        Post post = findPostById(postId); // 댓글을 달 게시물 조회
+
+        Comment comment = new Comment(request.getContent(), user, post);
+        Comment savedComment = commentRepository.save(comment);
+
+        return new CommentResponse(savedComment);
+    }
+
+    // 2. 특정 게시물의 댓글 목록 조회 (로그인 불필요)
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getCommentsByPostId(Long postId) {
+        // 게시물이 존재하는지 먼저 확인
+        Post post = findPostById(postId);
+
+        // 게시물 엔티티에서 직접 댓글 목록을 가져옴 (JPA 연관관계 활용)
+        List<Comment> comments = post.getComments();
+
+        // Comment 엔티티 리스트를 CommentResponse DTO 리스트로 변환
+        return comments.stream()
+                .map(CommentResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    // 3. 댓글 수정 (본인만 가능)
+    @Transactional
+    public CommentResponse updateComment(Long commentId, CommentUpdateRequest request) {
+        User user = getTemporaryUser(); // 임시 유저 (ID: 1L)
+        Comment comment = findCommentById(commentId);
+
+        // 본인 확인 (임시 유저 ID 1L 기준)
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.NO_AUTHORIZATION);
+        }
+
+        comment.update(request.getContent());
+        // @Transactional 어노테이션으로 인해 'Dirty checking'이 발생하므로
+        // commentRepository.save(comment)를 명시적으로 호출할 필요 없음.
+
+        return new CommentResponse(comment);
+    }
+
+    // 4. 댓글 삭제 (본인만 가능)
+    @Transactional
+    public void deleteComment(Long commentId) {
+        User user = getTemporaryUser(); // 임시 유저 (ID: 1L)
+        Comment comment = findCommentById(commentId);
+
+        // 본인 확인 (임시 유저 ID 1L 기준)
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.NO_AUTHORIZATION);
+        }
+
+        commentRepository.delete(comment);
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/service/CommentService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/service/CommentService.java
@@ -11,7 +11,6 @@ import com.leets.backend.blog_manage.exception.ErrorCode;
 import com.leets.backend.blog_manage.repository.CommentRepository;
 import com.leets.backend.blog_manage.repository.PostRepository;
 import com.leets.backend.blog_manage.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
@@ -23,7 +22,6 @@ public class CommentService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
 
-    @Autowired
     public CommentService(CommentRepository commentRepository, PostRepository postRepository, UserRepository userRepository) {
         this.commentRepository = commentRepository;
         this.postRepository = postRepository;

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/service/PostService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/service/PostService.java
@@ -9,7 +9,6 @@ import com.leets.backend.blog_manage.exception.CustomException;
 import com.leets.backend.blog_manage.exception.ErrorCode;
 import com.leets.backend.blog_manage.repository.PostRepository;
 import com.leets.backend.blog_manage.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -20,7 +19,6 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
 
-    @Autowired
     public PostService(PostRepository postRepository, UserRepository userRepository) {
         this.postRepository = postRepository;
         this.userRepository = userRepository;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

3주차에 구현한 게시물 REST API에 이어, 4주차 과제인 댓글 CRUD(생성, 조회, 수정, 삭제) API 기능을 구현했습니다.

또한, Postman과 같은 외부 도구 대신 API 문서를 확인하고 직접 테스트할 수 있는 Swagger UI 환경을 springdoc-openapi 라이브러리를 통해 구축했습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

임시 사용자 로직: 댓글의 생성, 수정, 삭제 시 권한 확인 로직이 3주차와 동일하게 임시 사용자(ID 1L)를 기준으로 동작합니다. 추후 실제 로그인 기능으로 교체가 필요합니다.

라이브러리 버전 충돌: Spring Boot 3.5.6 버전과 springdoc-openapi 2.5.0 버전 간의 호환성 문제로 인해, Swagger API 문서를 로드하는 과정에서 NoSuchMethodError가 발생하는 것을 확인했습니다.

해결: build.gradle의 Spring Boot 버전을 3.3.1로 수정하여 springdoc 라이브러리와의 버전 호환성 문제를 해결했습니다.

<br>

## 3. 관련 스크린샷을 첨부해주세요.


댓글 생성 (POST /api/posts/{postId}/comments)
<img width="1396" height="399" alt="2  댓글 생성" src="https://github.com/user-attachments/assets/d9f1013f-c168-4d61-9ab8-9dab133f5fea" />


댓글 목록 조회 (GET /api/posts/{postId}/comments)
<img width="1395" height="428" alt="3  댓글 목록 조회" src="https://github.com/user-attachments/assets/9980c204-c0ee-4ce7-ab31-02281361b1d0" />


댓글 수정 (PUT /api/comments/{commentId})
<img width="1392" height="404" alt="4  댓글 수정" src="https://github.com/user-attachments/assets/2c3f8968-f4b9-4c05-ad43-abdf65607a24" />


댓글 삭제 (DELETE /api/comments/{commentId})
<img width="1399" height="309" alt="5  댓글 삭제" src="https://github.com/user-attachments/assets/30f33bec-850b-4348-8289-a52efb9d9f0a" />


<br>

## 4. 완료 사항

댓글 CRUD(생성, 조회, 수정, 삭제) API 엔드포인트 4종 구현 완료

댓글 API 처리를 위한 DTO(Data Transfer Object) 3종 작성 (CommentCreateRequest, CommentUpdateRequest, CommentResponse)

요청 DTO에 @Valid를 이용한 유효성 검사 기능 추가

ErrorCode에 COMMENT_NOT_FOUND를 추가하고, CommentService 로직에 예외 처리 적용

build.gradle에 springdoc-openapi-starter-webmvc-ui 의존성을 추가하여 Swagger UI 연동 완료

<br>

## 5. 추가 사항

closed #75 

<br>