### PR TITLE
[5주차] 성현준/[feat] 이메일 회원가입 및 로그인 기능 구현

### DIFF
--- a/blog_manage/build.gradle
+++ b/blog_manage/build.gradle
@@ -24,6 +24,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test' // 테스트용
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // Jackson 의존성
+
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/controller/AuthController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/controller/AuthController.java
@@ -1,4 +1,55 @@
 package com.leets.backend.blog_manage.controller;
 
+import com.leets.backend.blog_manage.common.ApiResponse;
+import com.leets.backend.blog_manage.dto.auth.LoginRequest;
+import com.leets.backend.blog_manage.dto.auth.SignUpRequest;
+import com.leets.backend.blog_manage.dto.auth.TokenResponse;
+import com.leets.backend.blog_manage.entity.User;
+import com.leets.backend.blog_manage.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "인증 (Auth) API", description = "사용자 회원가입 및 로그인 관련 API")
+@RestController
+@RequestMapping("/api/auth")
 public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Operation(summary = "이메일 회원가입", description = "이메일과 비밀번호, 닉네임 등으로 회원가입합니다.")
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Object>> signUp(@Valid @RequestBody SignUpRequest request) {
+        User savedUser = authService.signUp(request);
+
+        // 회원가입 성공 시, 응답 본문에 별도 데이터 없이 성공 메시지만 반환
+        return new ResponseEntity<>(
+                ApiResponse.success("회원가입이 성공적으로 완료되었습니다.", null),
+                HttpStatus.CREATED
+        );
+    }
+
+    @Operation(summary = "이메일 로그인", description = "이메일과 비밀번호로 로그인합니다. 성공 시 AccessToken을 반환하고 RefreshToken을 쿠키에 설정합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenResponse>> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response) { // RefreshToken을 쿠키로 받기 위해 Response 객체 필요
+
+        TokenResponse tokenResponse = authService.login(request, response);
+
+        return ResponseEntity.ok(
+                ApiResponse.success("로그인 성공", tokenResponse)
+        );
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/controller/AuthController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/controller/AuthController.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog_manage.controller;
+
+public class AuthController {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/LoginRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/LoginRequest.java
@@ -1,4 +1,20 @@
 package com.leets.backend.blog_manage.dto.auth;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
 public class LoginRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 형식이 적합하지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    public String getEmail() { return email; }
+    public String getPassword() { return password; }
+
+    public void setEmail(String email) { this.email = email; }
+    public void setPassword(String password) { this.password = password; }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/LoginRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/LoginRequest.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog_manage.dto.auth;
+
+public class LoginRequest {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/SignUpRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/SignUpRequest.java
@@ -1,4 +1,70 @@
 package com.leets.backend.blog_manage.dto.auth;
 
+import com.leets.backend.blog_manage.entity.User;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 public class SignUpRequest {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 형식이 적합하지 않습니다.")
+    @Size(max = 100)
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인을 입력해주세요.")
+    private String passwordConfirm;
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    @Size(max = 10, message = "이름은 최대 10글자 입니다.")
+    private String name;
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    @Size(max = 20, message = "닉네임은 최대 20글자 입니다.")
+    private String nickname;
+
+    private LocalDate birthDate;
+
+    @Size(max = 30, message = "한 줄 소개는 최대 30글자 입니다.")
+    private String introduction;
+
+    // --- Getters ---
+    public String getEmail() { return email; }
+    public String getPassword() { return password; }
+    public String getPasswordConfirm() { return passwordConfirm; }
+    public String getName() { return name; }
+    public String getNickname() { return nickname; }
+    public LocalDate getBirthDate() { return birthDate; }
+    public String getIntroduction() { return introduction; }
+
+    // --- Setters (필요시) ---
+    public void setEmail(String email) { this.email = email; }
+    public void setPassword(String password) { this.password = password; }
+    public void setPasswordConfirm(String passwordConfirm) { this.passwordConfirm = passwordConfirm; }
+    public void setName(String name) { this.name = name; }
+    public void setNickname(String nickname) { this.nickname = nickname; }
+    public void setBirthDate(LocalDate birthDate) { this.birthDate = birthDate; }
+    public void setIntroduction(String introduction) { this.introduction = introduction; }
+
+    // DTO를 Entity로 변환 (비밀번호 암호화 포함)
+    public User toEntity(PasswordEncoder passwordEncoder) {
+        return User.builder()
+                .email(this.email)
+                .password(passwordEncoder.encode(this.password)) // 비밀번호 암호화
+                .nickname(this.nickname)
+                .name(this.name)
+                .profileImageUrl("default_profile_image_url") // 기본값 설정 (피그마 참고)
+                .birthDate(this.birthDate)
+                .introduction(this.introduction)
+                .loginType("EMAIL") // 이메일 가입
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/SignUpRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/SignUpRequest.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog_manage.dto.auth;
+
+public class SignUpRequest {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/TokenResponse.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/TokenResponse.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog_manage.dto.auth;
+
+public class TokenResponse {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/TokenResponse.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/dto/auth/TokenResponse.java
@@ -1,4 +1,21 @@
 package com.leets.backend.blog_manage.dto.auth;
 
 public class TokenResponse {
+
+    private String accessToken;
+
+    // 생성자
+    public TokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    // --- Getter ---
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    // --- Setter ---
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/entity/RefreshToken.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/entity/RefreshToken.java
@@ -23,7 +23,38 @@ public class RefreshToken {
 
     public RefreshToken() {}
 
-    // --- Getters ---
+    private RefreshToken(RefreshTokenBuilder builder) {
+        this.id = builder.id;
+        this.token = builder.token;
+        this.expiryDate = builder.expiryDate;
+        this.user = builder.user;
+    }
+
+    public static RefreshTokenBuilder builder() {
+        return new RefreshTokenBuilder();
+    }
+
+    public void updateToken(String token, LocalDateTime expiryDate) {
+        this.token = token;
+        this.expiryDate = expiryDate;
+    }
+
+    public static class RefreshTokenBuilder {
+        private Long id;
+        private String token;
+        private LocalDateTime expiryDate;
+        private User user;
+
+        public RefreshTokenBuilder id(Long id) { this.id = id; return this; }
+        public RefreshTokenBuilder token(String token) { this.token = token; return this; }
+        public RefreshTokenBuilder expiryDate(LocalDateTime expiryDate) { this.expiryDate = expiryDate; return this; }
+        public RefreshTokenBuilder user(User user) { this.user = user; return this; }
+
+        public RefreshToken build() {
+            return new RefreshToken(this);
+        }
+    }
+
     public Long getId() { return id; }
     public String getToken() { return token; }
     public LocalDateTime getExpiryDate() { return expiryDate; }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/entity/User.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/entity/User.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "user") // 테이블 이름을 명시적으로 지정
+@Table(name = "user")
 public class User {
 
     @Id
@@ -20,6 +20,7 @@ public class User {
     @Column(nullable = false)
     private String password;
 
+    // ... 나머지 필드들 ...
     @Column(length = 20, nullable = false, unique = true)
     private String nickname;
 
@@ -51,9 +52,60 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<Comment> comments = new ArrayList<>();
 
+
     public User() {}
 
-    // --- Getters ---
+    private User(UserBuilder builder) {
+        this.id = builder.id;
+        this.email = builder.email;
+        this.password = builder.password;
+        this.nickname = builder.nickname;
+        this.name = builder.name;
+        this.profileImageUrl = builder.profileImageUrl;
+        this.birthDate = builder.birthDate;
+        this.introduction = builder.introduction;
+        this.loginType = builder.loginType;
+        this.kakaoId = builder.kakaoId;
+        this.createdAt = builder.createdAt;
+        this.updatedAt = builder.updatedAt;
+    }
+
+    public static UserBuilder builder() {
+        return new UserBuilder();
+    }
+
+    public static class UserBuilder {
+        private Long id;
+        private String email;
+        private String password;
+        private String nickname;
+        private String name;
+        private String profileImageUrl;
+        private LocalDate birthDate;
+        private String introduction;
+        private String loginType;
+        private String kakaoId;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public UserBuilder id(Long id) { this.id = id; return this; }
+        public UserBuilder email(String email) { this.email = email; return this; }
+        public UserBuilder password(String password) { this.password = password; return this; }
+        public UserBuilder nickname(String nickname) { this.nickname = nickname; return this; }
+        public UserBuilder name(String name) { this.name = name; return this; }
+        public UserBuilder profileImageUrl(String profileImageUrl) { this.profileImageUrl = profileImageUrl; return this; }
+        public UserBuilder birthDate(LocalDate birthDate) { this.birthDate = birthDate; return this; }
+        public UserBuilder introduction(String introduction) { this.introduction = introduction; return this; }
+        public UserBuilder loginType(String loginType) { this.loginType = loginType; return this; }
+        public UserBuilder kakaoId(String kakaoId) { this.kakaoId = kakaoId; return this; }
+        public UserBuilder createdAt(LocalDateTime createdAt) { this.createdAt = createdAt; return this; }
+        public UserBuilder updatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; return this; }
+
+        public User build() {
+            return new User(this);
+        }
+    }
+
     public Long getId() { return id; }
     public String getEmail() { return email; }
     public String getPassword() { return password; }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/exception/ErrorCode.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/exception/ErrorCode.java
@@ -5,6 +5,12 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 400 Bad Request
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+
+    // 401 Unauthorized
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
 
     // 403 Forbidden
     NO_AUTHORIZATION(HttpStatus.FORBIDDEN, "권한이 없습니다."),
@@ -12,7 +18,13 @@ public enum ErrorCode {
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다."),
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레시 토큰을 찾을 수 없습니다."),
+
+    // 409 Conflict
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/exception/GlobalExceptionHandler.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.leets.backend.blog_manage.exception;
 
 import com.leets.backend.blog_manage.common.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException; // [추가]
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    // @Valid 유효성 검사 실패 시
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ApiResponse<Object>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
         String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
@@ -16,10 +18,28 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, ErrorCode.INVALID_INPUT_VALUE.getStatus());
     }
 
+    // 커스텀 예외 처리
     @ExceptionHandler(CustomException.class)
     protected ResponseEntity<ApiResponse<Object>> handleCustomException(CustomException ex) {
         ErrorCode errorCode = ex.getErrorCode();
         ApiResponse<Object> response = ApiResponse.error(errorCode.getMessage());
         return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    // Spring Security의 AccessDeniedException 처리 (권한 없음)
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ApiResponse<Object>> handleAccessDeniedException(AccessDeniedException ex) {
+        ErrorCode errorCode = ErrorCode.NO_AUTHORIZATION;
+        ApiResponse<Object> response = ApiResponse.error(errorCode.getMessage());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    // 기타 처리되지 않은 예외
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiResponse<Object>> handleException(Exception ex) {
+        // 로그 기록
+        // logger.error("Unhandled exception: ", ex);
+        ApiResponse<Object> response = ApiResponse.error("서버 내부 오류가 발생했습니다.");
+        return new ResponseEntity<>(response, org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/repository/RefreshTokenRepository.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/repository/RefreshTokenRepository.java
@@ -1,9 +1,14 @@
 package com.leets.backend.blog_manage.repository;
 
 import com.leets.backend.blog_manage.entity.RefreshToken;
+import com.leets.backend.blog_manage.entity.User; // [추가]
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional; // [추가]
+
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUser(User user);
+    Optional<RefreshToken> findByToken(String token); // 토큰 값으로 찾는 경우
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/repository/UserRepository.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/repository/UserRepository.java
@@ -4,6 +4,11 @@ import com.leets.backend.blog_manage.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional; // [추가]
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/config/SecurityConfig.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/config/SecurityConfig.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog_manage.security.config;
+
+public class SecurityConfig {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/config/SecurityConfig.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/config/SecurityConfig.java
@@ -1,4 +1,90 @@
 package com.leets.backend.blog_manage.security.config;
 
+import com.leets.backend.blog_manage.security.jwt.JwtAuthenticationFilter;
+import com.leets.backend.blog_manage.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // --- CORS 설정 빈 ---
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        // 모든 Origin 허용 (개발용)
+        configuration.setAllowedOrigins(Arrays.asList("*"));
+        // 모든 HTTP Method 허용
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        // 모든 Header 허용
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(false); // (JWT 사용 시 credential 불필요)
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 적용
+        return source;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // ---  CORS 설정 적용 ---
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+                // CSRF, HTTP Basic, Form Login 비활성화
+                .csrf(csrf -> csrf.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .formLogin(formLogin -> formLogin.disable())
+
+                // 세션 STATELESS 설정
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // URL별 권한 설정
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/auth/signup", "/api/auth/login").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+
+                // ---  401/403 에러 핸들링 ---
+                .exceptionHandling(exceptions -> exceptions
+                        // 인증되지 않은 사용자가 접근 시 401
+                        .authenticationEntryPoint((request, response, authException) ->
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증되지 않았습니다."))
+                        // 인증은 되었으나 권한이 없는 경우 403
+                        .accessDeniedHandler((request, response, accessDeniedException) ->
+                                response.sendError(HttpServletResponse.SC_FORBIDDEN, "권한이 없습니다."))
+                )
+
+                // JwtAuthenticationFilter 추가
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/config/SecurityConfig.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/config/SecurityConfig.java
@@ -5,6 +5,8 @@ import com.leets.backend.blog_manage.security.jwt.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager; // [추가]
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration; // [추가]
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -31,6 +33,12 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    // AuthenticationManager를 Bean으로 등록
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
     // --- CORS 설정 빈 ---

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/config/SwaggerConfig.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/config/SwaggerConfig.java
@@ -1,4 +1,42 @@
 package com.leets.backend.blog_manage.security.config;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        // API 기본 정보 설정
+        Info info = new Info()
+                .title("Leets Blog API")
+                .version("v1.0.0")
+                .description("블로그 프로젝트 API 명세서");
+
+        // --- [핵심] JWT 보안 스키마 정의 ---
+        String jwtSchemeName = "bearerAuth"; // SecurityScheme의 이름 (임의 지정 가능)
+
+        // 1. 보안 요구사항 정의 (어떤 스키마를 사용할지)
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        // 2. 보안 스키마 정의 (JWT Bearer 방식)
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName) // 스키마 이름
+                        .type(SecurityScheme.Type.HTTP) // 타입: HTTP
+                        .scheme("bearer") // 스키마: bearer
+                        .bearerFormat("JWT")); // 베어러 포맷: JWT
+
+        // 3. OpenAPI 객체에 정보 및 보안 설정 추가
+        return new OpenAPI()
+                .info(info)
+                .addSecurityItem(securityRequirement) // 전역 보안 요구사항 추가
+                .components(components); // 컴포넌트에 보안 스키마 추가
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/config/SwaggerConfig.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/config/SwaggerConfig.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog_manage.security.config;
+
+public class SwaggerConfig {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/jwt/JwtAuthenticationFilter.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,39 @@
 package com.leets.backend.blog_manage.security.jwt;
 
-public class JwtAuthenticationFilter {
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 1. Request Header에서 JWT 토큰 추출
+        String token = jwtTokenProvider.resolveToken(request);
+
+        // 2. validateToken으로 토큰 유효성 검사
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가져옴
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            // SecurityContext에 Authentication 객체를 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        // 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/jwt/JwtAuthenticationFilter.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog_manage.security.jwt;
+
+public class JwtAuthenticationFilter {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/jwt/JwtTokenProvider.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/jwt/JwtTokenProvider.java
@@ -1,4 +1,129 @@
 package com.leets.backend.blog_manage.security.jwt;
 
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
 public class JwtTokenProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtTokenProvider.class);
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final Key key;
+    private final long accessTokenExpirationTime;
+    private final long refreshTokenExpirationTime;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-expiration}") long accessTokenExpirationTime,
+            @Value("${jwt.refresh-token-expiration}") long refreshTokenExpirationTime) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+        this.accessTokenExpirationTime = accessTokenExpirationTime;
+        this.refreshTokenExpirationTime = refreshTokenExpirationTime;
+    }
+
+    // Access Token 생성
+    public String createAccessToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+        Date expiryDate = new Date(now + accessTokenExpirationTime);
+
+        return Jwts.builder()
+                .setSubject(authentication.getName()) // User의 이메일
+                .claim(AUTHORITIES_KEY, authorities)
+                .setIssuedAt(new Date(now))
+                .setExpiration(expiryDate)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    // Refresh Token 생성 (만료 시간 외에는 Access Token과 유사하게 생성)
+    public String createRefreshToken(Authentication authentication) {
+        long now = (new Date()).getTime();
+        Date expiryDate = new Date(now + refreshTokenExpirationTime);
+
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .setIssuedAt(new Date(now))
+                .setExpiration(expiryDate)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    // 토큰으로 Authentication 객체 생성
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication 반환
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            logger.warn("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            logger.warn("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            logger.warn("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            logger.warn("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    // 토큰에서 Claims 정보 추출
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰이더라도 Claims는 반환
+            return e.getClaims();
+        }
+    }
+
+    // 토큰에서 이메일(Subject) 추출
+    public String getEmailFromToken(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    // Request Header에서 토큰 정보 추출
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/jwt/JwtTokenProvider.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog_manage.security.jwt;
+
+public class JwtTokenProvider {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/service/CustomUserDetails.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/service/CustomUserDetails.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog_manage.security.service;
+
+public class CustomUserDetails {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/service/CustomUserDetails.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/service/CustomUserDetails.java
@@ -1,4 +1,61 @@
 package com.leets.backend.blog_manage.security.service;
 
-public class CustomUserDetails {
+import com.leets.backend.blog_manage.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+// (No-Lombok)
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    // User 엔티티를 반환하는 getter
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 우선 간단하게 모든 사용자에게 "ROLE_USER" 권한 부여
+        // 추후 User 엔티티에 Role 필드 추가 시 수정
+        return Collections.singletonList(() -> "ROLE_USER");
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail(); // 로그인 ID로 이메일 사용
+    }
+
+    // --- 계정 상태 관련 메소드 (DB에 필드 추가 시 로직 변경) ---
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/service/CustomUserDetailsService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/service/CustomUserDetailsService.java
@@ -1,4 +1,28 @@
 package com.leets.backend.blog_manage.security.service;
 
-public class CustomUserDetailsService {
+import com.leets.backend.blog_manage.entity.User;
+import com.leets.backend.blog_manage.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 찾을 수 없습니다: " + email));
+
+        return new CustomUserDetails(user);
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/security/service/CustomUserDetailsService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/security/service/CustomUserDetailsService.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog_manage.security.service;
+
+public class CustomUserDetailsService {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/service/AuthService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/service/AuthService.java
@@ -1,4 +1,127 @@
 package com.leets.backend.blog_manage.service;
 
+import com.leets.backend.blog_manage.dto.auth.LoginRequest;
+import com.leets.backend.blog_manage.dto.auth.SignUpRequest;
+import com.leets.backend.blog_manage.dto.auth.TokenResponse;
+import com.leets.backend.blog_manage.entity.RefreshToken;
+import com.leets.backend.blog_manage.entity.User;
+import com.leets.backend.blog_manage.exception.CustomException;
+import com.leets.backend.blog_manage.exception.ErrorCode;
+import com.leets.backend.blog_manage.repository.RefreshTokenRepository;
+import com.leets.backend.blog_manage.repository.UserRepository;
+import com.leets.backend.blog_manage.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Service
 public class AuthService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final long refreshTokenExpirationMillis;
+
+    public AuthService(UserRepository userRepository,
+                       RefreshTokenRepository refreshTokenRepository,
+                       PasswordEncoder passwordEncoder,
+                       JwtTokenProvider jwtTokenProvider,
+                       AuthenticationManagerBuilder authenticationManagerBuilder,
+                       @Value("${jwt.refresh-token-expiration}") long refreshTokenExpirationMillis) {
+        this.userRepository = userRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.authenticationManagerBuilder = authenticationManagerBuilder;
+        this.refreshTokenExpirationMillis = refreshTokenExpirationMillis;
+    }
+
+    // 1. 회원가입
+    @Transactional
+    public User signUp(SignUpRequest request) {
+        // 비밀번호 일치 확인
+        if (!request.getPassword().equals(request.getPasswordConfirm())) {
+            throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
+        }
+        // 이메일 중복 확인
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+        // 닉네임 중복 확인
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+
+        User user = request.toEntity(passwordEncoder);
+        return userRepository.save(user);
+    }
+
+    // 2. 로그인
+    @Transactional
+    public TokenResponse login(LoginRequest request, HttpServletResponse response) {
+        // 1. Login ID/PW를 기반으로 Authentication 객체 생성
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
+
+        // 2. 실제 검증 (CustomUserDetailsService 사용)
+        Authentication authentication;
+        try {
+            authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        } catch (Exception e) {
+            // 인증 실패
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        // 3. 인증 정보를 기반으로 JWT 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+        String refreshTokenString = jwtTokenProvider.createRefreshToken(authentication);
+
+        // 4. RefreshToken DB에 저장 (User와 1:1)
+        User user = userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        LocalDateTime expiryDate = LocalDateTime.now().plus(refreshTokenExpirationMillis, ChronoUnit.MILLIS);
+
+        RefreshToken refreshToken = refreshTokenRepository.findByUser(user)
+                .orElse(RefreshToken.builder().user(user).build()); // 없으면 새로 생성
+
+        refreshToken.updateToken(refreshTokenString, expiryDate);
+        refreshTokenRepository.save(refreshToken);
+
+        // 5. RefreshToken을 HttpOnly Secure 쿠키에 담아 응답
+        addRefreshTokenToCookie(response, refreshTokenString);
+
+        // 6. AccessToken은 응답 본문에 담아 반환
+        return new TokenResponse(accessToken);
+    }
+
+    // RefreshToken을 쿠키에 추가하는 헬퍼 메소드
+    private void addRefreshTokenToCookie(HttpServletResponse response, String refreshToken) {
+        // 쿠키 만료 시간을 초 단위로 설정
+        long maxAgeInSeconds = refreshTokenExpirationMillis / 1000;
+
+        Cookie cookie = new Cookie("refresh_token", refreshToken);
+        cookie.setHttpOnly(true); // JS에서 접근 불가
+        cookie.setSecure(true); // HTTPS에서만 전송 (운영 환경)
+        cookie.setPath("/"); // 사이트 전체에서 사용
+        cookie.setMaxAge((int) maxAgeInSeconds); // 쿠키 만료 시간 설정
+
+        // SameSite=Strict (혹은 Lax) 설정으로 CSRF 방어
+        // Spring 5.1+ 에서는 ResponseCookie 빌더 사용 권장되나, 기본 Cookie로도 설정 가능
+        // cookie.setAttribute("SameSite", "Strict");
+        // (참고: Spring Boot 2.7+ 에서는 application.yml에서 server.servlet.cookie.same-site=strict 설정 가능)
+
+        response.addCookie(cookie);
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/service/AuthService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/service/AuthService.java
@@ -13,8 +13,8 @@ import com.leets.backend.blog_manage.security.jwt.JwtTokenProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -30,20 +30,20 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final AuthenticationManager authenticationManager;
     private final long refreshTokenExpirationMillis;
 
     public AuthService(UserRepository userRepository,
                        RefreshTokenRepository refreshTokenRepository,
                        PasswordEncoder passwordEncoder,
                        JwtTokenProvider jwtTokenProvider,
-                       AuthenticationManagerBuilder authenticationManagerBuilder,
+                       AuthenticationManager authenticationManager,
                        @Value("${jwt.refresh-token-expiration}") long refreshTokenExpirationMillis) {
         this.userRepository = userRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtTokenProvider = jwtTokenProvider;
-        this.authenticationManagerBuilder = authenticationManagerBuilder;
+        this.authenticationManager = authenticationManager;
         this.refreshTokenExpirationMillis = refreshTokenExpirationMillis;
     }
 
@@ -67,7 +67,7 @@ public class AuthService {
         return userRepository.save(user);
     }
 
-    // 2. 로그인
+    // 2. 로그인 (리팩토링됨)
     @Transactional
     public TokenResponse login(LoginRequest request, HttpServletResponse response) {
         // 1. Login ID/PW를 기반으로 Authentication 객체 생성
@@ -77,33 +77,46 @@ public class AuthService {
         // 2. 실제 검증 (CustomUserDetailsService 사용)
         Authentication authentication;
         try {
-            authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+            // 주입받은 authenticationManager 사용
+            authentication = authenticationManager.authenticate(authenticationToken);
         } catch (Exception e) {
             // 인증 실패
             throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
         }
 
-        // 3. 인증 정보를 기반으로 JWT 토큰 생성
+        // 3. 인증 정보를 기반으로 AccessToken 생성
         String accessToken = jwtTokenProvider.createAccessToken(authentication);
-        String refreshTokenString = jwtTokenProvider.createRefreshToken(authentication);
 
-        // 4. RefreshToken DB에 저장 (User와 1:1)
-        User user = userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        LocalDateTime expiryDate = LocalDateTime.now().plus(refreshTokenExpirationMillis, ChronoUnit.MILLIS);
-
-        RefreshToken refreshToken = refreshTokenRepository.findByUser(user)
-                .orElse(RefreshToken.builder().user(user).build()); // 없으면 새로 생성
-
-        refreshToken.updateToken(refreshTokenString, expiryDate);
-        refreshTokenRepository.save(refreshToken);
+        // 4. RefreshToken 생성 및 DB 저장 (별도 메소드로 분리)
+        String refreshTokenString = createAndSaveRefreshToken(authentication);
 
         // 5. RefreshToken을 HttpOnly Secure 쿠키에 담아 응답
         addRefreshTokenToCookie(response, refreshTokenString);
 
         // 6. AccessToken은 응답 본문에 담아 반환
         return new TokenResponse(accessToken);
+    }
+
+    // [추가] RefreshToken 생성 및 저장을 담당하는 private 메소드
+    private String createAndSaveRefreshToken(Authentication authentication) {
+        // Refresh Token 생성
+        String refreshTokenString = jwtTokenProvider.createRefreshToken(authentication);
+
+        // User 조회
+        User user = userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 만료 시간 설정
+        LocalDateTime expiryDate = LocalDateTime.now().plus(refreshTokenExpirationMillis, ChronoUnit.MILLIS);
+
+        // RefreshToken 조회 및 업데이트 (없으면 새로 생성)
+        RefreshToken refreshToken = refreshTokenRepository.findByUser(user)
+                .orElse(RefreshToken.builder().user(user).build());
+
+        refreshToken.updateToken(refreshTokenString, expiryDate);
+        refreshTokenRepository.save(refreshToken);
+
+        return refreshTokenString;
     }
 
     // RefreshToken을 쿠키에 추가하는 헬퍼 메소드

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/service/AuthService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/service/AuthService.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog_manage.service;
+
+public class AuthService {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/service/CommentService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/service/CommentService.java
@@ -11,6 +11,7 @@ import com.leets.backend.blog_manage.exception.ErrorCode;
 import com.leets.backend.blog_manage.repository.CommentRepository;
 import com.leets.backend.blog_manage.repository.PostRepository;
 import com.leets.backend.blog_manage.repository.UserRepository;
+import org.springframework.security.core.context.SecurityContextHolder; // [추가]
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
@@ -28,12 +29,11 @@ public class CommentService {
         this.userRepository = userRepository;
     }
 
-
-    // PostService와 동일한 임시 사용자 조회 로직
-
-    private User getTemporaryUser() {
-        // 요구사항: 로그인 기능 구현 전이므로 임시 사용자(ID 1L) 사용
-        return userRepository.findById(1L)
+    // --- [수정] ---
+    // SecurityContext에서 인증된 사용자 정보를 가져오는 메소드
+    private User getAuthenticatedUser() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
@@ -52,8 +52,8 @@ public class CommentService {
     // 1. 댓글 생성
     @Transactional
     public CommentResponse createComment(Long postId, CommentCreateRequest request) {
-        User user = getTemporaryUser(); // 임시 유저 사용
-        Post post = findPostById(postId); // 댓글을 달 게시물 조회
+        User user = getAuthenticatedUser(); // [수정]
+        Post post = findPostById(postId);
 
         Comment comment = new Comment(request.getContent(), user, post);
         Comment savedComment = commentRepository.save(comment);
@@ -62,15 +62,11 @@ public class CommentService {
     }
 
     // 2. 특정 게시물의 댓글 목록 조회 (로그인 불필요)
+    // (이 메소드는 인증이 필요 없으므로 수정 사항 없음)
     @Transactional(readOnly = true)
     public List<CommentResponse> getCommentsByPostId(Long postId) {
-        // 게시물이 존재하는지 먼저 확인
         Post post = findPostById(postId);
-
-        // 게시물 엔티티에서 직접 댓글 목록을 가져옴 (JPA 연관관계 활용)
         List<Comment> comments = post.getComments();
-
-        // Comment 엔티티 리스트를 CommentResponse DTO 리스트로 변환
         return comments.stream()
                 .map(CommentResponse::new)
                 .collect(Collectors.toList());
@@ -79,28 +75,25 @@ public class CommentService {
     // 3. 댓글 수정 (본인만 가능)
     @Transactional
     public CommentResponse updateComment(Long commentId, CommentUpdateRequest request) {
-        User user = getTemporaryUser(); // 임시 유저 (ID: 1L)
+        User user = getAuthenticatedUser(); // [수정]
         Comment comment = findCommentById(commentId);
 
-        // 본인 확인 (임시 유저 ID 1L 기준)
+        // [수정]
         if (!comment.getUser().getId().equals(user.getId())) {
             throw new CustomException(ErrorCode.NO_AUTHORIZATION);
         }
 
         comment.update(request.getContent());
-        // @Transactional 어노테이션으로 인해 'Dirty checking'이 발생하므로
-        // commentRepository.save(comment)를 명시적으로 호출할 필요 없음.
-
         return new CommentResponse(comment);
     }
 
     // 4. 댓글 삭제 (본인만 가능)
     @Transactional
     public void deleteComment(Long commentId) {
-        User user = getTemporaryUser(); // 임시 유저 (ID: 1L)
+        User user = getAuthenticatedUser(); // [수정]
         Comment comment = findCommentById(commentId);
 
-        // 본인 확인 (임시 유저 ID 1L 기준)
+        // [수정]
         if (!comment.getUser().getId().equals(user.getId())) {
             throw new CustomException(ErrorCode.NO_AUTHORIZATION);
         }

--- a/blog_manage/src/main/java/com/leets/backend/blog_manage/service/PostService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog_manage/service/PostService.java
@@ -11,6 +11,7 @@ import com.leets.backend.blog_manage.repository.PostRepository;
 import com.leets.backend.blog_manage.repository.UserRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder; //
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,14 +25,16 @@ public class PostService {
         this.userRepository = userRepository;
     }
 
-    private User getTemporaryUser() {
-        return userRepository.findById(1L)
+    // SecurityContext에서 인증된 사용자 정보를 가져오는 메소드
+    private User getAuthenticatedUser() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
     @Transactional
     public Post createPost(PostCreateRequest request) {
-        User user = getTemporaryUser();
+        User user = getAuthenticatedUser();
         Post post = request.toEntity(user);
         return postRepository.save(post);
     }
@@ -49,8 +52,10 @@ public class PostService {
 
     @Transactional
     public void updatePost(Long postId, PostUpdateRequest request) {
+        User user = getAuthenticatedUser();
         Post post = findPostById(postId);
-        if (!post.getUser().getId().equals(1L)) {
+
+        if (!post.getUser().getId().equals(user.getId())) {
             throw new CustomException(ErrorCode.NO_AUTHORIZATION);
         }
         post.update(request.getTitle(), request.getContent());
@@ -58,8 +63,10 @@ public class PostService {
 
     @Transactional
     public void deletePost(Long postId) {
+        User user = getAuthenticatedUser();
         Post post = findPostById(postId);
-        if (!post.getUser().getId().equals(1L)) {
+
+        if (!post.getUser().getId().equals(user.getId())) {
             throw new CustomException(ErrorCode.NO_AUTHORIZATION);
         }
         postRepository.delete(post);

--- a/blog_manage/src/main/resources/application.yml
+++ b/blog_manage/src/main/resources/application.yml
@@ -10,3 +10,9 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
+
+
+jwt:
+  secret: "a-very-long-and-secure-secret-key-for-this-project-replace-it-later" # 32바이트 이상의 복잡한 문자열 사용 권장
+  access-token-expiration: 3600000 # 1시간 (밀리초 단위)
+  refresh-token-expiration: 604800000 # 7일 (밀리초 단위)


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

5주차 과제인 Spring Security와 JWT 토큰 기반 인증/인가 기능을 구현했습니다.
이메일 회원가입(/api/auth/signup) 및 로그인(/api/auth/login) API를 개발하였으며, 로그인 방식은 요구사항에 따라 Refresh Token을 HttpOnly 쿠키로 전달하는 방식을 채택했습니다.

또한, 기존 게시물과 댓글 서비스(PostService, CommentService)에서 사용하던 임시 사용자(ID 1L) 로직을, SecurityContext에서 실제 인증된 사용자 정보를 가져오도록 전면 리팩토링했습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

* Swagger Authorize 버튼 누락: SecurityConfig만으로는 Swagger UI에 API 테스트를 위한 인증 버튼이 나타나지 않는 문제가 있었습니다.
    * 해결: SwaggerConfig.java를 별도로 생성하여, SecurityScheme (JWT Bearer)을 정의하고 OpenAPI Bean에 전역 보안 설정을 추가함으로써 Authorize 버튼을 활성화했습니다.

* Swagger 401 인증 실패 (Bearer 중복): Authorize 버튼에 표준 형식인 Bearer {토큰}을 입력 시, Swagger가 Bearer를 자동으로 한 번 더 붙여 Authorization: Bearer Bearer {토큰}으로 전송하는 문제가 발생했습니다.
    * 해결: JwtTokenProvider가 토큰 파싱에 실패하여 401 에러를 반환하는 것을 확인. Swagger의 Authorize 버튼은 순수 토큰 값(ey...)만 입력해야 Bearer가 한 번만 정상적으로 추가됨을 확인하고 테스트 방식을 수정했습니다.

* Security 403 기본 에러 페이지: 토큰 없이 인증 API 호출 시, GlobalExceptionHandler가 아닌 Spring Security의 기본 403 HTML 에러 페이지가 응답되었습니다.
    * 해결: SecurityConfig의 .exceptionHandling()에 authenticationEntryPoint (401)와 accessDeniedHandler (403)를 명시적으로 설정하여, 서버가 일관된 에러 코드와 메시지를 반환하도록 수정했습니다.

<br>

## 3. 관련 스크린샷을 첨부해주세요.

회원가입 성공 (POST /api/auth/signup)
<img width="875" height="397" alt="스크린샷 2025-11-02 022818" src="https://github.com/user-attachments/assets/8ee933a4-40db-4584-b86c-08756410c981" />


로그인 성공 및 쿠키 확인 (POST /api/auth/login)
<img width="879" height="472" alt="스크린샷 2025-11-02 023010" src="https://github.com/user-attachments/assets/958c4302-dd1b-4b01-b905-6af5ee7e5e71" />
<img width="602" height="50" alt="스크린샷 2025-11-02 023045" src="https://github.com/user-attachments/assets/f3adfb0d-3814-436c-8478-8c52f9793212" />


게시물 생성 (POST /api/posts) - 인증 성공
<img width="879" height="514" alt="스크린샷 2025-11-02 024745" src="https://github.com/user-attachments/assets/95c1b215-ba33-4eb1-ba6c-b370e8e68d68" />


<br>

## 4. 완료 사항

* Spring Security, JWT(jjwt) 의존성 추가
* SecurityConfig: SecurityFilterChain Bean 설정 (CORS, CSRF, 세션, URL 권한, 401/403 핸들링)
* JwtTokenProvider, JwtAuthenticationFilter: JWT 토큰 생성, 검증, 필터 로직 구현
* CustomUserDetailsService, CustomUserDetails: Spring Security 사용자 조회 로직 구현
* AuthController, AuthService: 회원가입, 로그인 API 구현
* RefreshToken DB 저장 및 HttpOnly 쿠키 방식 적용 (요구사항 반영)
* SignUpRequest, LoginRequest, TokenResponse DTO 3종 작성
* PostService, CommentService: getTemporaryUser -> SecurityContextHolder 사용 리팩토링
* ErrorCode: 인증/인가 관련 에러 코드 추가
* SwaggerConfig: Swagger UI Authorize 버튼 연동 완료

<br>

## 5. 추가 사항

closed #88 

<br>