### PR TITLE
[5주차] 김지민/[feat] 이메일 로그인 및 회원가입 기능 구현 

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -21,3 +21,10 @@ springdoc:
     path: /swagger-ui
     operationsSorter: method
     tagsSorter: alpha
+
+
+security:
+  jwt:
+    secret: g7Wn9vKzE9f3HqV4zD0OErfYh8cKq6LxT0ZzB+Q8m9GfHkP7d9Sxv2Aq9rV1p3Wn==
+    access-exp: 1800
+    refresh-exp: 1209600

--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,16 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'com.mysql:mysql-connector-j:8.4.0'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0' //스웨거
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.test{

--- a/src/main/java/com/leets/backend/blog/auth/JwtTokenProvider.java
+++ b/src/main/java/com/leets/backend/blog/auth/JwtTokenProvider.java
@@ -1,0 +1,77 @@
+package com.leets.backend.blog.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+    private final long accessValidityMs;
+    private final String issuer;
+
+    public JwtTokenProvider(
+            @Value("${security.jwt.secret}") String secret,
+            @Value("${security.jwt.access-validity-seconds:1800}") long accessValiditySeconds,
+            @Value("${security.jwt.issuer:leets}") String issuer
+    ) {
+        // 비밀키는 최소 32바이트 이상 권장. (HMAC-SHA256)
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessValidityMs = accessValiditySeconds * 1000L;
+        this.issuer = issuer;
+    }
+
+    public String createAccessToken(String subject) {
+        Date now = new Date();
+        Date exp = new Date(now.getTime() + accessValidityMs);
+
+        return Jwts.builder()
+                .setSubject(subject)
+                .setIssuer(issuer)
+                .setIssuedAt(now)
+                .setExpiration(exp)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+
+    public String getSubject(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public Date getExpiration(String token) {
+        return parseClaims(token).getExpiration();
+    }
+
+    public long getRemainingSeconds(String token) {
+        Date exp = getExpiration(token);
+        long diffMs = exp.getTime() - System.currentTimeMillis();
+        return Math.max(0, diffMs / 1000L);
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/leets/backend/blog/auth/TokenHash.java
+++ b/src/main/java/com/leets/backend/blog/auth/TokenHash.java
@@ -1,0 +1,18 @@
+package com.leets.backend.blog.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public final class TokenHash {
+    private TokenHash(){}
+
+    public static byte[] sha256(String plaintext){
+        try{
+            MessageDigest md= MessageDigest.getInstance("SHA-256");
+            return md.digest(plaintext.getBytes(StandardCharsets.UTF_8));
+        }catch(NoSuchAlgorithmException e){
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
+++ b/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
@@ -1,0 +1,87 @@
+package com.leets.backend.blog.config;
+
+import com.leets.backend.blog.auth.JwtTokenProvider;
+import com.leets.backend.blog.security.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.cors.*;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(org.springframework.security.config.annotation.web.builders.HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+
+                .cors(Customizer.withDefaults())
+                .exceptionHandling(ex -> {})
+
+                //세션 X
+                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 인가
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/auth/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/v3/api-docs.yaml",
+                                "/swagger-resources/**"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/posts/**", "/comments/post/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    // 비밀번호 인코더
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration cfg = new CorsConfiguration();
+        cfg.setAllowedOrigins(List.of("*"));
+        cfg.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
+        cfg.setAllowedHeaders(List.of("*"));
+        cfg.setAllowCredentials(false);
+        cfg.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", cfg);
+        return source;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/config/SwaggerConfig.java
+++ b/src/main/java/com/leets/backend/blog/config/SwaggerConfig.java
@@ -1,7 +1,8 @@
 package com.leets.backend.blog.config;
 
+
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.*;
+import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/com/leets/backend/blog/controller/AuthController.java
+++ b/src/main/java/com/leets/backend/blog/controller/AuthController.java
@@ -1,0 +1,44 @@
+package com.leets.backend.blog.controller;
+
+import com.leets.backend.blog.dto.LoginRequest;
+import com.leets.backend.blog.dto.LoginResponse;
+import com.leets.backend.blog.dto.SignupRequest;
+import com.leets.backend.blog.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest req) {
+        authService.register(req);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest req) {
+        return ResponseEntity.ok(authService.login(req));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<String> refresh(@RequestBody String refreshTokenPlain) {
+        return ResponseEntity.ok(authService.refreshAccess(refreshTokenPlain));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestBody String refreshTokenPlain) {
+        authService.logout(refreshTokenPlain);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/leets/backend/blog/controller/CommentController.java
+++ b/src/main/java/com/leets/backend/blog/controller/CommentController.java
@@ -10,9 +10,9 @@ import com.leets.backend.blog.entity.Comment;
 import com.leets.backend.blog.service.CommentService;
 import java.util.List;
 
-@Tag(name = "댓글", description = "댓글 CRUD REST API")
+@Tag(name = "댓글", description = "댓글 CRUD REST API (posts 하위 리소스)")
 @RestController
-@RequestMapping("/comments")
+@RequestMapping("/posts/{postId}/comments")
 public class CommentController {
 
     private final CommentService commentService;
@@ -20,28 +20,31 @@ public class CommentController {
         this.commentService = commentService;
     }
 
-    @Operation(summary="댓글 목록 조회")
-    @GetMapping("/post/{postId}")
+    @Operation(summary="특정 게시물의 댓글 목록 조회")
+    @GetMapping
     public List<CommentResponse> getCommentsByPost(@PathVariable Long postId) {
         return commentService.getCommentResponsesByPost(postId);
     }
 
     @Operation(summary="댓글 생성")
     @PostMapping
-    public CommentResponse create(@RequestBody CommentCreateRequest request) {
+    public CommentResponse create(@PathVariable Long postId,
+                                  @RequestBody CommentCreateRequest request) {
         Comment comment = commentService.create(
-                request.getPostId(),
+                postId,
                 request.getUserId(),
                 request.getContent()
         );
         return new CommentResponse(comment);
     }
-    
+
     @Operation(summary="댓글 수정")
     @PatchMapping("/{commentId}")
-    public CommentResponse update(@PathVariable Long commentId,
+    public CommentResponse update(@PathVariable Long postId,
+                                  @PathVariable Long commentId,
                                   @RequestBody CommentUpdateRequest request) {
         Comment updated = commentService.update(
+                postId,
                 commentId,
                 request.getUserId(),
                 request.getNewContent()
@@ -51,9 +54,9 @@ public class CommentController {
 
     @Operation(summary = "댓글 삭제")
     @DeleteMapping("/{commentId}")
-    public void delete(@PathVariable Long commentId,
+    public void delete(@PathVariable Long postId,
+                       @PathVariable Long commentId,
                        @RequestParam Long userId) {
-        commentService.delete(commentId, userId);
+        commentService.delete(postId, commentId, userId);
     }
-
 }

--- a/src/main/java/com/leets/backend/blog/dto/LoginRequest.java
+++ b/src/main/java/com/leets/backend/blog/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.leets.backend.blog.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+
+    public String getEmail() { return email; }
+    public String getPassword() { return password; }
+}

--- a/src/main/java/com/leets/backend/blog/dto/LoginResponse.java
+++ b/src/main/java/com/leets/backend/blog/dto/LoginResponse.java
@@ -1,0 +1,13 @@
+package com.leets.backend.blog.dto;
+
+public class LoginResponse {
+    private final String accessToken;
+    private final String refreshToken;
+
+    public LoginResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+    public String getAccessToken() { return accessToken; }
+    public String getRefreshToken() { return refreshToken; }
+}

--- a/src/main/java/com/leets/backend/blog/dto/SignupRequest.java
+++ b/src/main/java/com/leets/backend/blog/dto/SignupRequest.java
@@ -1,0 +1,32 @@
+package com.leets.backend.blog.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class SignupRequest {
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String pas;
+
+    @NotBlank
+    private String nick;
+
+    @NotBlank
+    private String name;
+
+    public SignupRequest() {}
+
+    public String getEmail() {return email;}
+    public String getPassword() {return pas;}
+    public String getNickname() {return nick;}
+    public String getName(){return name;}
+
+    public void setEmail(String email) {this.email = email;}
+    public void setPassword(String pas) {this.pas = pas;}
+    public void setNickname(String nick) {this.nick = nick;}
+    public void setName(String name) {this.name = name;}
+
+}

--- a/src/main/java/com/leets/backend/blog/entity/Token.java
+++ b/src/main/java/com/leets/backend/blog/entity/Token.java
@@ -23,7 +23,14 @@ public class Token {
     private LocalDateTime expiredAt;
 
     public Token(){}
-
+    public static Token of(User user, byte[] tokenHash, LocalDateTime issuedAt, LocalDateTime expiredAt) {
+        Token token = new Token();
+        token.user = user;
+        token.tokenHash = tokenHash;
+        token.issuedAt = issuedAt;
+        token.expiredAt = expiredAt;
+        return token;
+    }
     public Long getId(){return id;}
     public User getUser(){return user;}
     public byte[] getTokenHash(){return tokenHash;}

--- a/src/main/java/com/leets/backend/blog/entity/User.java
+++ b/src/main/java/com/leets/backend/blog/entity/User.java
@@ -52,6 +52,16 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<Token> tokens=new ArrayList<>();
 
+    public static User createLocal(String email, String encodedPas, String nick, String name) {
+        User u = new User();
+        u.authIdentities = "local";
+        u.email = email;
+        u.pas = encodedPas;
+        u.nick = nick;
+        u.name=name;
+        u.createdAt = LocalDateTime.now();
+        return u;
+    }
     public Long getId(){return id;}
     public String getAuthIdentities(){return authIdentities;}
     public String getEmail(){return email;}

--- a/src/main/java/com/leets/backend/blog/repository/TokenRepository.java
+++ b/src/main/java/com/leets/backend/blog/repository/TokenRepository.java
@@ -1,0 +1,16 @@
+package com.leets.backend.blog.repository;
+
+import com.leets.backend.blog.entity.Token;
+import com.leets.backend.blog.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    Optional<Token> findByTokenHash(byte[] tokenHash);
+    List<Token> findByUser(User user);
+    long deleteByExpiredAtBefore(LocalDateTime expiredAt);
+    long deleteByUser(User user);
+}

--- a/src/main/java/com/leets/backend/blog/repository/UserRepository.java
+++ b/src/main/java/com/leets/backend/blog/repository/UserRepository.java
@@ -9,4 +9,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByNick(String nick);
+    boolean existsByEmail(String email);
 }
+
+

--- a/src/main/java/com/leets/backend/blog/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/leets/backend/blog/security/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.leets.backend.blog.security;
+
+import com.leets.backend.blog.auth.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.*;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            String subject = jwtTokenProvider.getSubject(token);
+            Authentication auth = new UsernamePasswordAuthenticationToken(subject, null, Collections.emptyList());
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String hdr = request.getHeader("Authorization");
+        if (hdr != null && hdr.startsWith("Bearer ")) {
+            return hdr.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/service/AuthService.java
+++ b/src/main/java/com/leets/backend/blog/service/AuthService.java
@@ -1,0 +1,78 @@
+package com.leets.backend.blog.service;
+
+import com.leets.backend.blog.auth.JwtTokenProvider;
+import com.leets.backend.blog.dto.LoginRequest;
+import com.leets.backend.blog.dto.LoginResponse;
+import com.leets.backend.blog.dto.SignupRequest;
+import com.leets.backend.blog.entity.Token;
+import com.leets.backend.blog.entity.User;
+import com.leets.backend.blog.repository.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtProvider; // 네가 쓰는 구현 재사용
+    private final TokenService tokenService;
+
+    public AuthService(UserRepository userRepository,
+                       PasswordEncoder passwordEncoder,
+                       JwtTokenProvider jwtProvider,
+                       TokenService tokenService) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtProvider = jwtProvider;
+        this.tokenService = tokenService;
+    }
+
+
+    public void register(SignupRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+        }
+        if (userRepository.existsByNick(request.getNickname())) {
+            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+        }
+
+        String encoded = passwordEncoder.encode(request.getPassword());
+
+        User user = User.createLocal(request.getEmail(), encoded, request.getNickname(), request.getName());
+        userRepository.save(user);
+    }
+
+
+    public LoginResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPas())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String accessToken = jwtProvider.createAccessToken(user.getEmail());
+        String refreshTokenPlain = tokenService.issueRefreshToken(user);
+
+        return new LoginResponse(accessToken, refreshTokenPlain);
+    }
+
+    public String refreshAccess(String refreshPlain) {
+        Optional<Token> tokenOpt = tokenService.verifyRefreshToken(refreshPlain);
+        if (tokenOpt.isEmpty()) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+        User user = tokenOpt.get().getUser();
+        return jwtProvider.createAccessToken(user.getEmail());
+    }
+
+
+    public void logout(String refreshPlain) {
+        tokenService.revoke(refreshPlain);
+    }
+}

--- a/src/main/java/com/leets/backend/blog/service/CommentService.java
+++ b/src/main/java/com/leets/backend/blog/service/CommentService.java
@@ -21,12 +21,12 @@ public class CommentService {
     }
 
     public Comment create(Long postId, Long userId, String content){
-        Post post=postRepository.findById(postId)
-                .orElseThrow(()->new IllegalArgumentException("해당 게시글을 찾을 수 없어요"));
-        User user=userRepository.findById(userId)
-                .orElseThrow(()->new IllegalArgumentException("해당 유저를 찾을 수 없어요"));
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글을 찾을 수 없어요"));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없어요"));
 
-        Comment comment=Comment.create(post, user, content);
+        Comment comment = Comment.create(post, user, content);
         return commentRepository.save(comment);
     }
 
@@ -36,27 +36,32 @@ public class CommentService {
         return comments.stream().map(CommentResponse::new).toList();
     }
 
-    public Comment update(Long commentId, Long userId, String newContent){
-        Comment comment=commentRepository.findById(commentId)
-                .orElseThrow(()->new IllegalArgumentException("댓글이 존재하지 않아요"));
+    public Comment update(Long postId, Long commentId, Long userId, String newContent){
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않아요"));
 
-        if(!comment.getAuthor().getId().equals(userId)){
+        if (!comment.getPost().getId().equals(postId)) {
+            throw new IllegalArgumentException("해당 게시글의 댓글이 아니에요");
+        }
+
+        if (!comment.getAuthor().getId().equals(userId)) {
             throw new IllegalArgumentException("댓글 작성자만 수정할 수 있어요");
-        };
+        }
 
         comment.updateContent(newContent);
         return comment;
     }
 
-    public void delete(Long commentId, Long userId){
-        Comment comment=commentRepository.findById(commentId)
-                .orElseThrow(()->new IllegalArgumentException("댓글이 존재하지 않아요"));
-
-        if(!comment.getAuthor().getId().equals(userId)){
+    public void delete(Long postId, Long commentId, Long userId){
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않아요"));
+        if (!comment.getPost().getId().equals(postId)) {
+            throw new IllegalArgumentException("해당 게시글의 댓글이 아니에요");
+        }
+        if (!comment.getAuthor().getId().equals(userId)) {
             throw new IllegalArgumentException("댓글 작성자만 삭제할 수 있어요");
         }
 
         commentRepository.delete(comment);
     }
-
 }

--- a/src/main/java/com/leets/backend/blog/service/TokenService.java
+++ b/src/main/java/com/leets/backend/blog/service/TokenService.java
@@ -1,0 +1,93 @@
+package com.leets.backend.blog.service;
+
+import com.leets.backend.blog.auth.TokenHash;
+import com.leets.backend.blog.entity.Token;
+import com.leets.backend.blog.entity.User;
+import com.leets.backend.blog.repository.TokenRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class TokenService {
+
+    private final TokenRepository tokenRepository;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    //리프레시 토큰 만료기간
+    private static final int REFRESH_DAYS = 14;
+
+    public TokenService(TokenRepository tokenRepository) {
+        this.tokenRepository = tokenRepository;
+    }
+
+    public String issueRefreshToken(User user) {
+        String plain = generateRandomToken();
+        byte[] hash = sha256(plain);
+
+        Token t = new Token();
+        setTokenFields(t, user, hash, LocalDateTime.now(),
+                LocalDateTime.now().plusDays(REFRESH_DAYS));
+
+        tokenRepository.save(t);
+        return plain;
+    }
+
+    public Optional<Token> verifyRefreshToken(String plain) {
+        byte[] hash = sha256(plain);
+        Optional<Token> opt = tokenRepository.findByTokenHash(hash);
+        if (opt.isEmpty()) return opt;
+        Token t = opt.get();
+        if (t.getExpiredAt() != null && t.getExpiredAt().isBefore(LocalDateTime.now())) {
+            // 만료된 토큰은 제거
+            tokenRepository.delete(t);
+            return Optional.empty();
+        }
+        return opt;
+    }
+
+    public void revoke(String plain) {
+        verifyRefreshToken(plain).ifPresent(tokenRepository::delete);
+    }
+
+    private String generateRandomToken() {
+        byte[] buf = new byte[32]; // 256-bit
+        secureRandom.nextBytes(buf);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(buf);
+    }
+
+    private byte[] sha256(String v) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return md.digest(v.getBytes(StandardCharsets.UTF_8)); // 32 bytes
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private void setTokenFields(Token t, User user, byte[] hash, LocalDateTime issued, LocalDateTime expired) {
+        try {
+            var userF = Token.class.getDeclaredField("user");
+            var tokenHashF = Token.class.getDeclaredField("tokenHash");
+            var issuedAtF = Token.class.getDeclaredField("issuedAt");
+            var expiredAtF = Token.class.getDeclaredField("expiredAt");
+            userF.setAccessible(true);
+            tokenHashF.setAccessible(true);
+            issuedAtF.setAccessible(true);
+            expiredAtF.setAccessible(true);
+            userF.set(t, user);
+            tokenHashF.set(t, hash);
+            issuedAtF.set(t, issued);
+            expiredAtF.set(t, expired);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Token 엔티티에 세터가 없어 필드 주입에 실패했습니다.", e);
+        }
+    }
+}


### PR DESCRIPTION
### 개요
이메일 기반 로그인 및 회원가입 기능을 구현했습니다.
JWT 액세스/리프레시 토큰 발급 구조를 적용하고, 리프레시 토큰을 DB에 해시 형태로 저장하였습니다.

### 주요 변경 사항
1. 회원 가입 (/auth/signup)
 - 이메일, 닉네임, 비밀번호, 이름 등 입력값 검증 추가 (`@Valid`, `@Email`, `@NotBlank`)
 - 이메일 닉네임 중복 체크 로직 추가
<img width="665" height="1173" alt="스크린샷 2025-11-04 224945" src="https://github.com/user-attachments/assets/830ea4e9-557b-4624-93b8-129be08e05c6" />

2. 로그인 (/auth/login)
 - 이메일 및 비밀번호 검증
 - 로그인 성공 시 엑세스 토큰+리프레시 토큰 발급
<img width="663" height="1253" alt="스크린샷 2025-11-04 225008" src="https://github.com/user-attachments/assets/6c1d03d4-52c2-45a0-9a8a-a54d8aa5c8f1" />

3. 로그아웃
<img width="942" height="918" alt="스크린샷 2025-11-04 225117" src="https://github.com/user-attachments/assets/bc8b5e33-d9f6-42ba-b8c7-9a6d77349e77" />

4. 댓글 목록 확인 관련 변경 
 (comments/post/postid)에서 변경하였습니다. 
<img width="1232" height="1369" alt="스크린샷 2025-11-04 232756" src="https://github.com/user-attachments/assets/29adcaee-b131-4ea0-a672-3c61c4b96b52" />
