### PR TITLE
[5주차] 박소윤/[feat] 로그인 및 인증,인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     // JJWT: JWT(JSON Web Token)를 생성하고 검증하기 위한 라이브러리
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     // JJWT: JWT(JSON Web Token)를 생성하고 검증하기 위한 라이브러리
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
+++ b/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
@@ -1,31 +1,63 @@
 package com.leets.backend.blog.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean; // 1. import 추가
+import org.springframework.context.annotation.Configuration; // 2. import 추가
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.leets.backend.blog.config.jwt.JwtAuthenticationFilter;
+import com.leets.backend.blog.config.jwt.JwtTokenProvider; // 3. import 추가
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
+    // 4. JwtTokenProvider 주입을 위한 필드 선언
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private static final String[] SWAGGER_PATHS = {
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
+    };
+
+    // 5. 생성자를 통해 JwtTokenProvider 주입
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring()
+                .requestMatchers("/favicon.ico")
+                .requestMatchers(SWAGGER_PATHS)
+                .requestMatchers("/error"); 
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-
-                .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-                .authorizeHttpRequests(authz -> authz
-
-                        .requestMatchers(HttpMethod.GET, "/posts", "/posts/**").permitAll()
-
-                        // 과제 진행을 위해 나머지 모든 요청은 일단 임시로 허용
-                        .anyRequest().permitAll()
-                );
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(authz -> authz
+                    
+                    // 6. [중요] URL 권한 설정 수정
+                    // 과제 요구사항: 회원가입(/auth), 로그인(/login)은 인증 없이 접근 가능해야 함
+                    .requestMatchers("/auth/**", "/login").permitAll() 
+                    .requestMatchers(HttpMethod.GET, "/posts", "/posts/**").permitAll()
+                    
+                    // 7. [중요] 위에서 정의한 경로 외의 모든 요청은 인증(로그인)이 필요함
+                    .anyRequest().authenticated() 
+            )
+            // 8. [핵심] JwtAuthenticationFilter를 UsernamePasswordAuthenticationFilter 앞에 추가
+            // (UsernamePasswordAuthenticationFilter: Spring Security의 기본 로그인 필터)
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), 
+                             UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
+++ b/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
@@ -1,24 +1,31 @@
 package com.leets.backend.blog.config;
 
-import org.springframework.context.annotation.Bean; // 1. import 추가
-import org.springframework.context.annotation.Configuration; // 2. import 추가
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager; // 1. RefreshTokenRepository import 추가
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import com.leets.backend.blog.config.jwt.JwtAuthenticationFilter;
-import com.leets.backend.blog.config.jwt.JwtTokenProvider; // 3. import 추가
+import com.leets.backend.blog.config.jwt.JwtLoginFilter;
+import com.leets.backend.blog.config.jwt.JwtTokenProvider;
+import com.leets.backend.blog.repository.RefreshTokenRepository;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
-    // 4. JwtTokenProvider 주입을 위한 필드 선언
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final RefreshTokenRepository refreshTokenRepository; // 2. Repository 필드 추가
 
     private static final String[] SWAGGER_PATHS = {
             "/v3/api-docs/**",
@@ -26,9 +33,23 @@ public class SecurityConfig {
             "/swagger-ui.html"
     };
 
-    // 5. 생성자를 통해 JwtTokenProvider 주입
-    public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
+    // 3. 생성자 수정 (RefreshTokenRepository 주입)
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider,
+                          AuthenticationConfiguration authenticationConfiguration,
+                          RefreshTokenRepository refreshTokenRepository) { // 3. 주입 받기
         this.jwtTokenProvider = jwtTokenProvider;
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.refreshTokenRepository = refreshTokenRepository; // 3. 초기화
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+    
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 
     @Bean
@@ -41,24 +62,30 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        
+        AuthenticationManager authenticationManager = authenticationManager(authenticationConfiguration);
+
+        // 4. [수정] JwtLoginFilter 인스턴스 생성 시 Repository 주입
+        JwtLoginFilter jwtLoginFilter = new JwtLoginFilter(
+                authenticationManager, 
+                jwtTokenProvider, 
+                refreshTokenRepository // 4. Repository 전달
+        );
+        jwtLoginFilter.setFilterProcessesUrl("/login");
+
         http
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authz -> authz
                     
-                    // 6. [중요] URL 권한 설정 수정
-                    // 과제 요구사항: 회원가입(/auth), 로그인(/login)은 인증 없이 접근 가능해야 함
                     .requestMatchers("/auth/**", "/login").permitAll() 
                     .requestMatchers(HttpMethod.GET, "/posts", "/posts/**").permitAll()
-                    
-                    // 7. [중요] 위에서 정의한 경로 외의 모든 요청은 인증(로그인)이 필요함
                     .anyRequest().authenticated() 
             )
-            // 8. [핵심] JwtAuthenticationFilter를 UsernamePasswordAuthenticationFilter 앞에 추가
-            // (UsernamePasswordAuthenticationFilter: Spring Security의 기본 로그인 필터)
-            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), 
-                             UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+            .addFilterAt(jwtLoginFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 }
+

--- a/src/main/java/com/leets/backend/blog/config/SwaggerConfig.java
+++ b/src/main/java/com/leets/backend/blog/config/SwaggerConfig.java
@@ -1,11 +1,16 @@
 package com.leets.backend.blog.config;
 
+import org.springframework.context.annotation.Bean; // 1. import 추가
+import org.springframework.context.annotation.Configuration; // 2. import 추가
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-
+@OpenAPIDefinition( // 3. 애너테이션 추가
+        servers = @Server(url = "http://localhost:8080")
+)
 @Configuration
 public class SwaggerConfig {
 

--- a/src/main/java/com/leets/backend/blog/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/leets/backend/blog/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.leets.backend.blog.config.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * 클라이언트 요청 시 JWT 인증을 수행하는 필터
+ * OncePerRequestFilter: 모든 서블릿 요청에 대해 단 한 번만 실행되도록 보장
+ */
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // JwtTokenProvider를 주입받음
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    /**
+     * 실제 필터링 로직
+     * 토큰을 검사하여 유효하면 SecurityContext에 인증 정보를 저장
+     */
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        // 1. Request Header에서 토큰 추출
+        String token = resolveToken(request);
+
+        // 2. 토큰 유효성 검사
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            // 3. 토큰이 유효할 경우, 토큰에서 Authentication 객체 가져오기
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            
+            // 4. SecurityContext에 Authentication 객체 저장
+            // (이로써 Spring Security가 이 사용자를 '인증된 사용자'로 인식함)
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        // 5. 다음 필터 체인으로 전달
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Request Header에서 "Authorization" 헤더를 찾아 토큰(Bearer 접두사 제거)을 추출
+     * @param request
+     * @return 추출된 토큰 (없으면 null)
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7); // "Bearer " (7글자) 이후의 토큰 반환
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/config/jwt/JwtLoginFilter.java
+++ b/src/main/java/com/leets/backend/blog/config/jwt/JwtLoginFilter.java
@@ -1,0 +1,109 @@
+package com.leets.backend.blog.config.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.AuthenticationManager; // 1. RefreshToken 임포트
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken; // 2. User 임포트
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter; // 3. RefreshTokenRepository 임포트
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.leets.backend.blog.domain.RefreshToken;
+import com.leets.backend.blog.domain.User;
+import com.leets.backend.blog.dto.TokenInfo;
+import com.leets.backend.blog.dto.UserLoginRequestDto;
+import com.leets.backend.blog.repository.RefreshTokenRepository;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * POST /login 요청을 처리하고, 인증 성공 시 JWT 토큰을 발급하는 필터
+ */
+public class JwtLoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository; // 4. Repository 주입
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public JwtLoginFilter(AuthenticationManager authenticationManager, 
+                            JwtTokenProvider jwtTokenProvider,
+                            RefreshTokenRepository refreshTokenRepository) { // 5. 생성자에 추가
+        this.authenticationManager = authenticationManager;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenRepository = refreshTokenRepository; // 6. 초기화
+        setFilterProcessesUrl("/login");
+    }
+
+    /**
+     * 1. 로그인 시도 (Authentication)
+     * (기존 코드와 동일)
+     */
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+        try {
+            UserLoginRequestDto loginRequestDto = objectMapper.readValue(request.getInputStream(), UserLoginRequestDto.class);
+
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                    loginRequestDto.getEmail(),
+                    loginRequestDto.getPassword(),
+                    null
+            );
+
+            return authenticationManager.authenticate(authToken);
+
+        } catch (IOException e) {
+            throw new RuntimeException("로그인 요청 처리 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 2. 인증 성공 (Successful Authentication)
+     * (DB 저장 로직 추가됨)
+     */
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                            FilterChain chain, Authentication authResult)
+            throws IOException, ServletException {
+
+        // 1. authResult (인증 결과)를 기반으로 JWT 토큰(Access, Refresh) 생성
+        TokenInfo tokenInfo = jwtTokenProvider.generateTokenInfo(authResult);
+
+        // 2. ========== Refresh Token DB에 저장 ==========
+        // authResult.getPrincipal()은 CustomUserDetailsService에서 반환한 UserDetails(User 객체)입니다.
+        User user = (User) authResult.getPrincipal();
+        Long userId = user.getId();
+        
+        // RefreshToken 엔티티 생성
+        RefreshToken refreshToken = new RefreshToken(userId, tokenInfo.getRefreshToken());
+        
+        // DB에 저장 (userId가 PK이므로, 이미 존재하면 UPDATE, 없으면 INSERT)
+        refreshTokenRepository.save(refreshToken);
+        // ===============================================
+
+        // 3. Response Body에 TokenInfo(JSON)를 담아 클라이언트에 응답
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(tokenInfo));
+    }
+
+    /**
+     * 3. 인증 실패 (Unsuccessful Authentication)
+     * (기존 코드와 동일)
+     */
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                                AuthenticationException failed) throws IOException, ServletException {
+        
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write("{\"error\": \"로그인 실패\", \"message\": \"" + failed.getMessage() + "\"}");
+    }
+}
+

--- a/src/main/java/com/leets/backend/blog/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/leets/backend/blog/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,175 @@
+package com.leets.backend.blog.config.jwt;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors; // 2. Logger import 추가
+
+import org.slf4j.Logger; // 3. LoggerFactory import 추가
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import com.leets.backend.blog.dto.TokenInfo;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+// @Slf4j // 4. Lombok 어노테이션 제거
+@Component
+public class JwtTokenProvider {
+
+    // 5. 표준 SLF4J 로거 선언
+    private static final Logger log = LoggerFactory.getLogger(JwtTokenProvider.class);
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String GRANT_TYPE = "Bearer";
+
+    private final Key key;
+    private final long accessTokenExpirationMs;
+    private final long refreshTokenExpirationMs;
+
+    // application.properties에서 비밀키와 만료 시간을 가져옵니다.
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-expiration-ms}") long accessTokenExpirationMs,
+            @Value("${jwt.refresh-token-expiration-ms}") long refreshTokenExpirationMs) {
+        
+        // 6. BASE6S64 -> BASE64 로 오타 수정
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey); 
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpirationMs = accessTokenExpirationMs;
+        this.refreshTokenExpirationMs = refreshTokenExpirationMs;
+    }
+
+    /**
+     * 1. 로그인 성공 후 호출: Access Token과 Refresh Token을 생성합니다.
+     * @param authentication Spring Security의 인증 정보
+     * @return TokenInfo (GrantType, AccessToken, RefreshToken)
+     */
+    public TokenInfo generateTokenInfo(Authentication authentication) {
+        // 1. 인증 정보에서 권한 목록 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+        
+        // 2. Access Token 생성
+        String accessToken = createAccessToken(authentication.getName(), authorities, now);
+
+        // 3. Refresh Token 생성
+        String refreshToken = createRefreshToken(now);
+
+        // 4. TokenInfo DTO에 담아 반환
+        return TokenInfo.of(GRANT_TYPE, accessToken, refreshToken);
+    }
+
+    /**
+     * 2. Access Token 생성 메서드
+     */
+    public String createAccessToken(String subject, String authorities, long now) {
+        Date accessTokenExpiresIn = new Date(now + this.accessTokenExpirationMs);
+        
+        return Jwts.builder()
+                .setSubject(subject) // 사용자 식별자 (우리는 email 사용)
+                .claim(AUTHORITIES_KEY, authorities) // 권한 정보
+                .setExpiration(accessTokenExpiresIn) // 만료 시간
+                .signWith(key, SignatureAlgorithm.HS256) // 서명
+                .compact();
+    }
+
+    /**
+     * 3. Refresh Token 생성 메서드
+     * (Refresh Token은 사용자 정보 없이 만료 시간만 가짐)
+     */
+    public String createRefreshToken(long now) {
+        Date refreshTokenExpiresIn = new Date(now + this.refreshTokenExpirationMs);
+
+        return Jwts.builder()
+                .setExpiration(refreshTokenExpiresIn) // 만료 시간
+                .signWith(key, SignatureAlgorithm.HS256) // 서명
+                .compact();
+    }
+
+    /**
+     * 4. 토큰 복호화: 토큰에서 인증 정보(Authentication)를 추출합니다.
+     * (이 메서드는 JwtAuthenticationFilter에서 사용됩니다)
+     * @param accessToken 검증할 Access Token
+     * @return Authentication 객체
+     */
+    public Authentication getAuthentication(String accessToken) {
+        // 1. 토큰에서 Claims (정보 단위) 추출
+        Claims claims = getClaims(accessToken);
+
+        if (claims.get(AUTHORITIES_KEY) == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        // 2. Claims에서 권한 정보(authorities) 추출
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        // 3. UserDetails 객체 생성 (principal: 사용자 식별자, 여기서는 email)
+        // User는 Spring Security가 제공하는 UserDetails 구현체입니다.
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+        // 4. Authentication 객체(UsernamePasswordAuthenticationToken) 반환
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    /**
+     * 5. 토큰 유효성 검증 메서드
+     * (이 메서드는 JwtAuthenticationFilter에서 사용됩니다)
+     * @param token 검증할 토큰
+     * @return 유효하면 true, 아니면 false
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.warn("잘못된 JWT 서명입니다.", e);
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰입니다.", e);
+            // TODO: Access Token 만료 시 Refresh Token을 사용한 재발급 로직 필요
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 토큰입니다.", e);
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT 토큰이 잘못되었습니다.", e);
+        }
+        return false;
+    }
+
+    /**
+     * (Helper) 토큰에서 Claims를 추출합니다.
+     */
+    private Claims getClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰이라도 Claims는 반환 (재발급 로직 등에서 사용 가능)
+            return e.getClaims();
+        }
+    }
+}
+

--- a/src/main/java/com/leets/backend/blog/controller/AuthController.java
+++ b/src/main/java/com/leets/backend/blog/controller/AuthController.java
@@ -10,12 +10,15 @@ import org.springframework.web.bind.annotation.RestController;
 import com.leets.backend.blog.dto.TokenInfo;
 import com.leets.backend.blog.dto.TokenReissueRequestDto;
 import com.leets.backend.blog.dto.UserSignUpRequestDto;
-// [추가] 로그인 DTO를 import 합니다.
 import com.leets.backend.blog.dto.UserLoginRequestDto;
 import com.leets.backend.blog.service.AuthService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.validation.Valid;
 
+@Tag(name = "Auth API", description = "사용자 인증(회원가입, 로그인, 토큰) 관련 API")
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
@@ -30,60 +33,34 @@ public class AuthController {
      * 회원가입 API
      * POST /auth
      */
+    @Operation(summary = "회원가입", description = "이메일, 닉네임, 비밀번호로 회원가입을 진행합니다.")
     @PostMapping
     public ResponseEntity<String> signUp(@Valid @RequestBody UserSignUpRequestDto requestDto) {
-        // 4. 예외 처리를 위해 try-catch 추가
-        try {
-            authService.signUp(requestDto);
-            return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 성공적으로 완료되었습니다.");
-        } catch (IllegalArgumentException e) {
-            // 이메일/닉네임 중복 시 400 Bad Request 반환
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
-        }
+        authService.signUp(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 성공적으로 완료되었습니다.");
     }
 
     /**
-     * [추가된 로그인 API]
      * 로그인 API
      * POST /auth/login
      */
+    @Operation(summary = "로그인", description = "이메일, 비밀번호로 로그인을 진행하고 토큰(Access, Refresh)을 발급받습니다.")
     @PostMapping("/login")
-    public ResponseEntity<?> login(@Valid @RequestBody UserLoginRequestDto requestDto) {
-        try {
-            // AuthService에 login(UserLoginRequestDto) 메소드가 구현되어 있어야 합니다.
-            // 이 메소드는 인증 성공 시 TokenInfo를 반환합니다.
-            TokenInfo tokenInfo = authService.login(requestDto);
-
-            // 로그인 성공 시 200 OK와 함께 토큰 정보(TokenInfo)를 응답 본문에 반환
-            return ResponseEntity.ok(tokenInfo);
-
-        } catch (IllegalArgumentException e) { // 또는 Spring Security의 AuthenticationException
-            // authService.login에서 이메일/비밀번호 불일치 시
-            // 예외를 발생시킨다고 가정합니다.
-            return ResponseEntity
-                    .status(HttpStatus.UNAUTHORIZED) // 401: 인증 실패
-                    .body(e.getMessage()); // "이메일 또는 비밀번호가 올바르지 않습니다."
-        }
+    public ResponseEntity<TokenInfo> login(@Valid @RequestBody UserLoginRequestDto requestDto) {
+        // !! try-catch 제거 !!
+        // 서비스에서 예외 발생 시 GlobalExceptionHandler가 처리합니다.
+        TokenInfo tokenInfo = authService.login(requestDto);
+        return ResponseEntity.ok(tokenInfo);
     }
 
-
     /**
-     * 5. 토큰 재발급 API 구현 (기존 코드)
+     * 토큰 재발급 API
      * POST /auth/reissue
      */
+    @Operation(summary = "토큰 재발급", description = "유효한 Refresh Token을 사용하여 Access Token과 Refresh Token을 재발급받습니다.")
     @PostMapping("/reissue")
-    public ResponseEntity<?> reissueToken(@Valid @RequestBody TokenReissueRequestDto requestDto) {
-        try {
-            // [수정된 부분]
-            // requestDto 객체 대신, 그 안의 Refresh Token 문자열을 전달합니다.
-            TokenInfo tokenInfo = authService.reissueToken(requestDto.getRefreshToken());
-
-            return ResponseEntity.ok(tokenInfo);
-        } catch (IllegalArgumentException e) {
-            // 유효하지 않은 토큰(만료, 위조, DB에 없음 등)일 경우 401 Unauthorized 반환
-            return ResponseEntity
-                    .status(HttpStatus.UNAUTHORIZED)
-                    .body(e.getMessage());
-        }
+    public ResponseEntity<TokenInfo> reissueToken(@Valid @RequestBody TokenReissueRequestDto requestDto) {
+        TokenInfo tokenInfo = authService.reissueToken(requestDto.getRefreshToken());
+        return ResponseEntity.ok(tokenInfo);
     }
 }

--- a/src/main/java/com/leets/backend/blog/controller/AuthController.java
+++ b/src/main/java/com/leets/backend/blog/controller/AuthController.java
@@ -1,15 +1,17 @@
 package com.leets.backend.blog.controller;
 
-import com.leets.backend.blog.dto.TokenInfo; // 1. import 추가
-import com.leets.backend.blog.dto.TokenReissueRequestDto; // 2. import 추가
-import org.springframework.http.HttpStatus; // 3. import 추가
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.leets.backend.blog.dto.TokenInfo;
+import com.leets.backend.blog.dto.TokenReissueRequestDto;
 import com.leets.backend.blog.dto.UserSignUpRequestDto;
+// [추가] 로그인 DTO를 import 합니다.
+import com.leets.backend.blog.dto.UserLoginRequestDto;
 import com.leets.backend.blog.service.AuthService;
 
 import jakarta.validation.Valid;
@@ -41,20 +43,47 @@ public class AuthController {
     }
 
     /**
-     * 5. 토큰 재발급 API 구현 (주석 해제 및 수정)
+     * [추가된 로그인 API]
+     * 로그인 API
+     * POST /auth/login
+     */
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@Valid @RequestBody UserLoginRequestDto requestDto) {
+        try {
+            // AuthService에 login(UserLoginRequestDto) 메소드가 구현되어 있어야 합니다.
+            // 이 메소드는 인증 성공 시 TokenInfo를 반환합니다.
+            TokenInfo tokenInfo = authService.login(requestDto);
+
+            // 로그인 성공 시 200 OK와 함께 토큰 정보(TokenInfo)를 응답 본문에 반환
+            return ResponseEntity.ok(tokenInfo);
+
+        } catch (IllegalArgumentException e) { // 또는 Spring Security의 AuthenticationException
+            // authService.login에서 이메일/비밀번호 불일치 시
+            // 예외를 발생시킨다고 가정합니다.
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED) // 401: 인증 실패
+                    .body(e.getMessage()); // "이메일 또는 비밀번호가 올바르지 않습니다."
+        }
+    }
+
+
+    /**
+     * 5. 토큰 재발급 API 구현 (기존 코드)
      * POST /auth/reissue
      */
     @PostMapping("/reissue")
     public ResponseEntity<?> reissueToken(@Valid @RequestBody TokenReissueRequestDto requestDto) {
         try {
-            TokenInfo tokenInfo = authService.reissueToken(requestDto);
+            // [수정된 부분]
+            // requestDto 객체 대신, 그 안의 Refresh Token 문자열을 전달합니다.
+            TokenInfo tokenInfo = authService.reissueToken(requestDto.getRefreshToken());
+
             return ResponseEntity.ok(tokenInfo);
         } catch (IllegalArgumentException e) {
             // 유효하지 않은 토큰(만료, 위조, DB에 없음 등)일 경우 401 Unauthorized 반환
             return ResponseEntity
-                    .status(HttpStatus.UNAUTHORIZED) 
+                    .status(HttpStatus.UNAUTHORIZED)
                     .body(e.getMessage());
         }
     }
 }
-

--- a/src/main/java/com/leets/backend/blog/controller/AuthController.java
+++ b/src/main/java/com/leets/backend/blog/controller/AuthController.java
@@ -1,0 +1,60 @@
+package com.leets.backend.blog.controller;
+
+import com.leets.backend.blog.dto.TokenInfo; // 1. import 추가
+import com.leets.backend.blog.dto.TokenReissueRequestDto; // 2. import 추가
+import org.springframework.http.HttpStatus; // 3. import 추가
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.leets.backend.blog.dto.UserSignUpRequestDto;
+import com.leets.backend.blog.service.AuthService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    /**
+     * 회원가입 API
+     * POST /auth
+     */
+    @PostMapping
+    public ResponseEntity<String> signUp(@Valid @RequestBody UserSignUpRequestDto requestDto) {
+        // 4. 예외 처리를 위해 try-catch 추가
+        try {
+            authService.signUp(requestDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 성공적으로 완료되었습니다.");
+        } catch (IllegalArgumentException e) {
+            // 이메일/닉네임 중복 시 400 Bad Request 반환
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
+    /**
+     * 5. 토큰 재발급 API 구현 (주석 해제 및 수정)
+     * POST /auth/reissue
+     */
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissueToken(@Valid @RequestBody TokenReissueRequestDto requestDto) {
+        try {
+            TokenInfo tokenInfo = authService.reissueToken(requestDto);
+            return ResponseEntity.ok(tokenInfo);
+        } catch (IllegalArgumentException e) {
+            // 유효하지 않은 토큰(만료, 위조, DB에 없음 등)일 경우 401 Unauthorized 반환
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED) 
+                    .body(e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/com/leets/backend/blog/controller/CommentController.java
+++ b/src/main/java/com/leets/backend/blog/controller/CommentController.java
@@ -17,6 +17,11 @@ import com.leets.backend.blog.dto.CommentSaveRequest;
 import com.leets.backend.blog.dto.CommentUpdateRequest;
 import com.leets.backend.blog.service.CommentService;
 
+// Swagger 어노테이션 임포트
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Comment API", description = "댓글 관련 API") // 1. @Tag 추가
 @RestController
 public class CommentController {
 
@@ -26,41 +31,41 @@ public class CommentController {
         this.commentService = commentService;
     }
 
+    @Operation(summary = "댓글 작성", description = "특정 게시글에 새 댓글을 작성합니다.") // 2. @Operation 추가
     @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<CommentResponse> saveComment(
             @PathVariable Long postId,
             @RequestBody CommentSaveRequest request
     ) {
-        Long currentUserId = 1L; 
-        CommentResponse response = commentService.save(postId, request, currentUserId);
+        CommentResponse response = commentService.save(postId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @Operation(summary = "게시글별 댓글 조회", description = "특정 게시글에 달린 모든 댓글을 조회합니다.") // 2. @Operation 추가
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<List<CommentResponse>> getCommentsByPost(
             @PathVariable Long postId
     ) {
-        Long currentUserId = 1L; // !! 임시 하드코딩.
-        List<CommentResponse> responses = commentService.findAllByPost(postId, currentUserId);
+        List<CommentResponse> responses = commentService.findAllByPost(postId);
         return ResponseEntity.ok(responses);
     }
 
+    @Operation(summary = "댓글 수정", description = "특정 댓글의 내용을 수정합니다.") // 2. @Operation 추가
     @PutMapping("/comments/{commentId}")
     public ResponseEntity<CommentResponse> updateComment(
             @PathVariable Long commentId,
             @RequestBody CommentUpdateRequest request
     ) {
-        Long currentUserId = 1L; // !! 임시 하드코딩.
-        CommentResponse response = commentService.update(commentId, request, currentUserId);
+        CommentResponse response = commentService.update(commentId, request);
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "댓글 삭제", description = "특정 댓글을 삭제합니다.") // 2. @Operation 추가
     @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<Void> deleteComment(
             @PathVariable Long commentId
     ) {
-        Long currentUserId = 1L; // !! 임시 하드코딩.
-        commentService.delete(commentId, currentUserId);
+        commentService.delete(commentId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/leets/backend/blog/controller/CommentController.java
+++ b/src/main/java/com/leets/backend/blog/controller/CommentController.java
@@ -31,7 +31,7 @@ public class CommentController {
         this.commentService = commentService;
     }
 
-    @Operation(summary = "댓글 작성", description = "특정 게시글에 새 댓글을 작성합니다.") // 2. @Operation 추가
+    @Operation(summary = "댓글 작성", description = "특정 게시글에 새 댓글을 작성합니다.")
     @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<CommentResponse> saveComment(
             @PathVariable Long postId,
@@ -60,7 +60,7 @@ public class CommentController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "댓글 삭제", description = "특정 댓글을 삭제합니다.") // 2. @Operation 추가
+    @Operation(summary = "댓글 삭제", description = "특정 댓글을 삭제합니다.")
     @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<Void> deleteComment(
             @PathVariable Long commentId

--- a/src/main/java/com/leets/backend/blog/controller/CommentController.java
+++ b/src/main/java/com/leets/backend/blog/controller/CommentController.java
@@ -1,0 +1,66 @@
+package com.leets.backend.blog.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.leets.backend.blog.dto.CommentResponse;
+import com.leets.backend.blog.dto.CommentSaveRequest;
+import com.leets.backend.blog.dto.CommentUpdateRequest;
+import com.leets.backend.blog.service.CommentService;
+
+@RestController
+public class CommentController {
+
+    private final CommentService commentService;
+
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<CommentResponse> saveComment(
+            @PathVariable Long postId,
+            @RequestBody CommentSaveRequest request
+    ) {
+        Long currentUserId = 1L; 
+        CommentResponse response = commentService.save(postId, request, currentUserId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<List<CommentResponse>> getCommentsByPost(
+            @PathVariable Long postId
+    ) {
+        Long currentUserId = 1L; // !! 임시 하드코딩.
+        List<CommentResponse> responses = commentService.findAllByPost(postId, currentUserId);
+        return ResponseEntity.ok(responses);
+    }
+
+    @PutMapping("/comments/{commentId}")
+    public ResponseEntity<CommentResponse> updateComment(
+            @PathVariable Long commentId,
+            @RequestBody CommentUpdateRequest request
+    ) {
+        Long currentUserId = 1L; // !! 임시 하드코딩.
+        CommentResponse response = commentService.update(commentId, request, currentUserId);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long commentId
+    ) {
+        Long currentUserId = 1L; // !! 임시 하드코딩.
+        commentService.delete(commentId, currentUserId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/leets/backend/blog/domain/Comment.java
+++ b/src/main/java/com/leets/backend/blog/domain/Comment.java
@@ -1,7 +1,17 @@
 package com.leets.backend.blog.domain;
 
-import jakarta.persistence.*;
 import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 
 @Entity
 public class Comment {
@@ -38,6 +48,17 @@ public class Comment {
     }
 
     public Comment() {}
+
+    public Comment(String content, Post post, User user) {
+        this.content = content;
+        this.post = post;
+        this.user = user;
+    }
+
+    public void updateContent(String newContent) {
+        this.content = newContent;
+    }
+
 
     public Long getId() {
         return id;

--- a/src/main/java/com/leets/backend/blog/domain/RefreshToken.java
+++ b/src/main/java/com/leets/backend/blog/domain/RefreshToken.java
@@ -13,12 +13,39 @@ public class RefreshToken {
     @Column(nullable = false)
     private String token;
 
+    // --- [수정/추가될 부분] ---
+
+    /**
+     * JPA를 위한 기본 생성자 (필수)
+     */
     public RefreshToken() {}
 
+    /**
+     * [추가] AuthService의 'new RefreshToken(user.getId())' 호출을 위한 생성자
+     * @param userId 토큰을 발급받는 사용자의 ID
+     */
+    public RefreshToken(Long userId) {
+        this.userId = userId;
+    }
+
+    /**
+     * (기존 코드) userId와 token을 모두 받는 생성자
+     */
     public RefreshToken(Long userId, String token) {
         this.userId = userId;
         this.token = token;
     }
+
+    /**
+     * [추가] AuthService의 'rt.updateToken(refreshToken)' 호출을 위한 메소드
+     * (기능은 setToken과 동일하지만, AuthService의 호출에 맞춰 이름을 제공합니다)
+     * @param token 새로 발급된 리프레시 토큰 문자열
+     */
+    public void updateToken(String token) {
+        this.token = token;
+    }
+
+    // --- (기존 Getter / Setter) ---
 
     public Long getUserId() {
         return userId;

--- a/src/main/java/com/leets/backend/blog/domain/User.java
+++ b/src/main/java/com/leets/backend/blog/domain/User.java
@@ -1,13 +1,28 @@
 package com.leets.backend.blog.domain;
 
-import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.List; // 1. import 추가
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails; // 2. import 추가
+
+import jakarta.persistence.CascadeType; // 3. import 추가
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "users")
-public class User {
+public class User implements UserDetails { // 4. UserDetails 구현
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -51,11 +66,14 @@ public class User {
 
     public User() {}
 
+    // --- 기존 Getter/Setter (변경 없음) ---
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
-    public String getPassword() { return password; }
+    
+    // UserDetails의 getPassword() 메서드를 만족시킴
+    public String getPassword() { return password; } 
     public void setPassword(String password) { this.password = password; }
     public String getNickname() { return nickname; }
     public void setNickname(String nickname) { this.nickname = nickname; }
@@ -71,4 +89,41 @@ public class User {
     public void setPosts(List<Post> posts) { this.posts = posts; }
     public List<Comment> getComments() { return comments; }
     public void setComments(List<Comment> comments) { this.comments = comments; }
+
+    
+    // 5. ========== UserDetails 구현 메서드 추가 ==========
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 현재 과제에서는 단순 "ROLE_USER" 권한만 부여합니다.
+        // 추후 Role 엔티티를 만들고 연관관계를 맺어 동적으로 관리할 수 있습니다.
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getUsername() {
+        // Spring Security에서 username은 ID를 의미합니다.
+        // 우리는 email을 ID로 사용하므로 email을 반환합니다.
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true; // 계정 만료 여부 (true: 만료되지 않음)
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true; // 계정 잠김 여부 (true: 잠기지 않음)
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true; // 비밀번호 만료 여부 (true: 만료되지 않음)
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true; // 계정 활성화 여부 (true: 활성화됨)
+    }
 }

--- a/src/main/java/com/leets/backend/blog/dto/CommentSaveRequest.java
+++ b/src/main/java/com/leets/backend/blog/dto/CommentSaveRequest.java
@@ -1,0 +1,20 @@
+package com.leets.backend.blog.dto;
+
+public class CommentSaveRequest {
+
+    private String content;
+
+    // JSON 역직렬화를 위한 기본 생성자
+    public CommentSaveRequest() {
+    }
+
+    // Getter
+    public String getContent() {
+        return content;
+    }
+
+    // Setter
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/dto/CommentUpdateRequest.java
+++ b/src/main/java/com/leets/backend/blog/dto/CommentUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.leets.backend.blog.dto;
+
+public class CommentUpdateRequest {
+
+    private String content;
+
+    // JSON 역직렬화를 위한 기본 생성자
+    public CommentUpdateRequest() {
+    }
+
+    // Getter
+    public String getContent() {
+        return content;
+    }
+
+    // Setter
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/dto/TokenInfo.java
+++ b/src/main/java/com/leets/backend/blog/dto/TokenInfo.java
@@ -1,0 +1,33 @@
+package com.leets.backend.blog.dto;
+
+public class TokenInfo {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+
+    // @Builder
+    public TokenInfo(String grantType, String accessToken, String refreshToken) {
+        this.grantType = grantType;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public static TokenInfo of(String grantType, String accessToken, String refreshToken) {
+        return new TokenInfo(grantType, accessToken, refreshToken);
+    }
+    
+    // --- Getters ---
+
+    public String getGrantType() {
+        return grantType;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/dto/TokenReissueRequestDto.java
+++ b/src/main/java/com/leets/backend/blog/dto/TokenReissueRequestDto.java
@@ -1,0 +1,19 @@
+package com.leets.backend.blog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class TokenReissueRequestDto {
+
+    @NotBlank(message = "Refresh Token은 필수입니다.")
+    private String refreshToken;
+
+    // --- Getter and Setter ---
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/dto/UserLoginRequestDto.java
+++ b/src/main/java/com/leets/backend/blog/dto/UserLoginRequestDto.java
@@ -1,0 +1,32 @@
+package com.leets.backend.blog.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class UserLoginRequestDto {
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    private String password;
+
+    // --- Getters and Setters ---
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/dto/UserSignUpRequestDto.java
+++ b/src/main/java/com/leets/backend/blog/dto/UserSignUpRequestDto.java
@@ -1,0 +1,48 @@
+package com.leets.backend.blog.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// @Getter, @Setter, @NoArgsConstructor 등 롬복(Lombok) 어노테이션을 사용하면 편합니다.
+// 여기서는 Lombok이 없다는 가정 하에 Getter/Setter를 포함했습니다.
+public class UserSignUpRequestDto {
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    private String password;
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    @Size(max = 20, message = "닉네임은 20자를 넘을 수 없습니다.")
+    private String nickname;
+
+    // --- Getters and Setters ---
+    
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/exception/CommentNotFoundException.java
+++ b/src/main/java/com/leets/backend/blog/exception/CommentNotFoundException.java
@@ -1,0 +1,8 @@
+package com.leets.backend.blog.exception;
+
+// 404 Not Found 용 Exception
+public class CommentNotFoundException extends RuntimeException {
+    public CommentNotFoundException(Long id) {
+        super("댓글을 찾을 수 없습니다. (ID: " + id + ")");
+    }
+}

--- a/src/main/java/com/leets/backend/blog/exception/CommentPermissionException.java
+++ b/src/main/java/com/leets/backend/blog/exception/CommentPermissionException.java
@@ -1,0 +1,16 @@
+package com.leets.backend.blog.exception;
+
+// 403 Forbidden 용 Exception
+public class CommentPermissionException extends RuntimeException {
+
+    // 기존 생성자 (Long, Long)
+    public CommentPermissionException(Long commentId, Long userId) {
+        super("댓글에 대한 권한이 없습니다. (Comment ID: " + commentId + ", User ID: " + (userId != null ? userId : "null") + ")");
+    }
+
+    // !! 에러 해결을 위해 이 생성자를 추가합니다 !!
+    // (String)을 받는 생성자
+    public CommentPermissionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/leets/backend/blog/exception/DuplicateDataException.java
+++ b/src/main/java/com/leets/backend/blog/exception/DuplicateDataException.java
@@ -1,0 +1,8 @@
+package com.leets.backend.blog.exception;
+
+// HTTP 400 Bad Request 용 (회원가입 시 이메일/닉네임 중복)
+public class DuplicateDataException extends RuntimeException {
+    public DuplicateDataException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/leets/backend/blog/exception/ErrorResponse.java
+++ b/src/main/java/com/leets/backend/blog/exception/ErrorResponse.java
@@ -1,14 +1,34 @@
 package com.leets.backend.blog.exception;
 
+// 1. HttpStatus 임포트 추가!
+import org.springframework.http.HttpStatus;
+
+// 클라이언트에게 반환할 에러 응답 DTO
 public class ErrorResponse {
+
+    // 1. status 필드 추가
     private final int status;
     private final String message;
 
+    // 2. (int, String) 생성자 추가
     public ErrorResponse(int status, String message) {
         this.status = status;
         this.message = message;
     }
 
-    public int getStatus() { return status; }
-    public String getMessage() { return message; }
+    // 3. (String) 생성자는 삭제하거나 그대로 두어도 됩니다.
+    //    (혹시 다른 곳에서 쓸 수도 있으니 그대로 두는 것을 추천합니다.)
+    public ErrorResponse(String message) {
+        // (int, String) 생성자를 재사용하도록 수정
+        this(HttpStatus.INTERNAL_SERVER_ERROR.value(), message);
+    }
+
+    // 4. status 필드의 Getter 추가
+    public int getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
 }

--- a/src/main/java/com/leets/backend/blog/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/leets/backend/blog/exception/GlobalExceptionHandler.java
@@ -2,36 +2,56 @@ package com.leets.backend.blog.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 
+// @RestControllerAdvice : 모든 @RestController에서 발생하는 예외를 처리
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(ResourceNotFoundException.class)
-    protected ResponseEntity<ErrorResponse> handleResourceNotFoundException(ResourceNotFoundException ex) {
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    // 404 Not Found 예외 그룹을 처리하는 핸들러
+    // (하나의 핸들러가 여러 예외를 처리할 수 있습니다)
+    @ExceptionHandler({
+            PostNotFoundException.class,
+            CommentNotFoundException.class,
+            UserNotFoundException.class
+    })
+    public ResponseEntity<ErrorResponse> handleNotFoundException(RuntimeException ex, WebRequest request) {
+
+        // 님의 ErrorResponse 형식(status, message)에 맞춰서 응답 생성
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.NOT_FOUND.value(), // 404
+                ex.getMessage() // 예외 클래스에서 설정한 메시지
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND); // 404
     }
 
-    @ExceptionHandler(AuthorizationException.class)
-    protected ResponseEntity<ErrorResponse> handleAuthorizationException(AuthorizationException ex) {
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.FORBIDDEN.value(), ex.getMessage());
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
+    // 403 Forbidden 예외를 처리하는 핸들러
+    @ExceptionHandler(CommentPermissionException.class)
+    public ResponseEntity<ErrorResponse> handlePermissionException(CommentPermissionException ex, WebRequest request) {
+
+        // 님의 ErrorResponse 형식(status, message)에 맞춰서 응답 생성
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.FORBIDDEN.value(), // 403
+                ex.getMessage()
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN); // 403
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-        String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), errorMessage);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
-    }
-
+    // (선택) 그 외 모든 500 Internal Server Error를 처리하는 핸들러
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse> handleException(Exception ex) {
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다.");
-        ex.printStackTrace();
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex, WebRequest request) {
+        // 중요: 실제 운영 환경에서는 로그를 남겨야 합니다.
+        ex.printStackTrace(); // 혹은 로거 사용
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(), // 500
+                "서버 내부 오류가 발생했습니다."
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR); // 500
     }
 }

--- a/src/main/java/com/leets/backend/blog/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/leets/backend/blog/exception/GlobalExceptionHandler.java
@@ -4,44 +4,70 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.context.request.WebRequest; // WebRequest 임포트
 
-// @RestControllerAdvice : 모든 @RestController에서 발생하는 예외를 처리
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // 404 Not Found 예외 그룹을 처리하는 핸들러
-    // (하나의 핸들러가 여러 예외를 처리할 수 있습니다)
+    // 404 Not Found 예외 그룹을 처리하는 핸들러 (님의 코드)
+    // (PostNotFound, CommentNotFound, UserNotFound)
     @ExceptionHandler({
             PostNotFoundException.class,
             CommentNotFoundException.class,
             UserNotFoundException.class
     })
     public ResponseEntity<ErrorResponse> handleNotFoundException(RuntimeException ex, WebRequest request) {
-
-        // 님의 ErrorResponse 형식(status, message)에 맞춰서 응답 생성
         ErrorResponse errorResponse = new ErrorResponse(
                 HttpStatus.NOT_FOUND.value(), // 404
-                ex.getMessage() // 예외 클래스에서 설정한 메시지
+                ex.getMessage()
         );
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND); // 404
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
-    // 403 Forbidden 예외를 처리하는 핸들러
+    // 403 Forbidden 예외를 처리하는 핸들러 (님의 코드)
     @ExceptionHandler(CommentPermissionException.class)
     public ResponseEntity<ErrorResponse> handlePermissionException(CommentPermissionException ex, WebRequest request) {
-
-        // 님의 ErrorResponse 형식(status, message)에 맞춰서 응답 생성
         ErrorResponse errorResponse = new ErrorResponse(
                 HttpStatus.FORBIDDEN.value(), // 403
                 ex.getMessage()
         );
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN); // 403
+        return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
 
-    // (선택) 그 외 모든 500 Internal Server Error를 처리하는 핸들러
+    // --- !! (리뷰 반영) Auth 관련 예외 핸들러 3개 추가 !! ---
+
+    // 400 Bad Request (회원가입 시 데이터 중복)
+    @ExceptionHandler(DuplicateDataException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateDataException(DuplicateDataException ex, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(), // 400
+                ex.getMessage()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    // 401 Unauthorized (로그인 실패)
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidCredentialsException(InvalidCredentialsException ex, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.UNAUTHORIZED.value(), // 401
+                ex.getMessage()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+
+    // 401 Unauthorized (토큰 유효하지 않음)
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidTokenException(InvalidTokenException ex, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.UNAUTHORIZED.value(), // 401
+                ex.getMessage()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+
+
+    // (선택) 그 외 모든 500 Internal Server Error를 처리하는 핸들러 (님의 코드)
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex, WebRequest request) {
         // 중요: 실제 운영 환경에서는 로그를 남겨야 합니다.
@@ -52,6 +78,6 @@ public class GlobalExceptionHandler {
                 "서버 내부 오류가 발생했습니다."
         );
 
-        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR); // 500
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/leets/backend/blog/exception/InvalidCredentialsException.java
+++ b/src/main/java/com/leets/backend/blog/exception/InvalidCredentialsException.java
@@ -1,0 +1,8 @@
+package com.leets.backend.blog.exception;
+
+// HTTP 401 Unauthorized 용 (로그인 시 자격 증명 실패)
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/leets/backend/blog/exception/InvalidTokenException.java
+++ b/src/main/java/com/leets/backend/blog/exception/InvalidTokenException.java
@@ -1,0 +1,8 @@
+package com.leets.backend.blog.exception;
+
+// HTTP 401 Unauthorized 용 (토큰 재발급 시 토큰 유효하지 않음)
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/leets/backend/blog/exception/PostNotFoundException.java
+++ b/src/main/java/com/leets/backend/blog/exception/PostNotFoundException.java
@@ -1,0 +1,8 @@
+package com.leets.backend.blog.exception;
+
+// 404 Not Found 용 Exception
+public class PostNotFoundException extends RuntimeException {
+    public PostNotFoundException(Long id) {
+        super("게시글을 찾을 수 없습니다. (ID: " + id + ")");
+    }
+}

--- a/src/main/java/com/leets/backend/blog/exception/UserNotFoundException.java
+++ b/src/main/java/com/leets/backend/blog/exception/UserNotFoundException.java
@@ -1,0 +1,8 @@
+package com.leets.backend.blog.exception;
+
+// 404 Not Found 용 Exception
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(Long id) {
+        super("사용자를 찾을 수 없습니다. (ID: " + id + ")");
+    }
+}

--- a/src/main/java/com/leets/backend/blog/repository/CommentRepository.java
+++ b/src/main/java/com/leets/backend/blog/repository/CommentRepository.java
@@ -1,9 +1,13 @@
 package com.leets.backend.blog.repository;
 
-import com.leets.backend.blog.domain.Comment;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import java.util.List;
 
-@Repository
+import org.springframework.data.jpa.repository.JpaRepository; 
+
+import com.leets.backend.blog.domain.Comment;
+import com.leets.backend.blog.domain.Post; 
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findByPost(Post post);
 }

--- a/src/main/java/com/leets/backend/blog/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/leets/backend/blog/repository/RefreshTokenRepository.java
@@ -1,0 +1,30 @@
+package com.leets.backend.blog.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.leets.backend.blog.domain.RefreshToken;
+
+/**
+ * RefreshToken을 DB에서 관리하기 위한 리포지토리
+ * RefreshToken 엔티티의 ID (PK) 타입이 Long (userId)이므로 JpaRepository<RefreshToken, Long>
+ */
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    // JpaRepository가 기본으로 제공하는 메서드들을 사용합니다.
+    // (e.g., save, findById, deleteById)
+
+    /**
+     * 토큰 재발급(reissue) 시, 토큰 값(문자열)으로 DB를 조회하기 위해 이 메서드가 필요합니다.
+     */
+    Optional<RefreshToken> findByToken(String token);
+
+    /**
+     * [추가]
+     * 로그인 시, 사용자 ID(FK)로 기존 토큰이 있는지 조회하기 위해 이 메서드가 필요합니다.
+     */
+    Optional<RefreshToken> findByUserId(Long userId);
+}

--- a/src/main/java/com/leets/backend/blog/repository/UserRepository.java
+++ b/src/main/java/com/leets/backend/blog/repository/UserRepository.java
@@ -1,9 +1,21 @@
 package com.leets.backend.blog.repository;
 
-import com.leets.backend.blog.domain.User;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.leets.backend.blog.domain.User; // 1. Optional 임포트 추가
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    // 2. 로그인 시 이메일로 사용자 조회를 위한 메서드 추가
+    Optional<User> findByEmail(String email);
+
+    // 3. 회원가입 시 이메일 중복 체크를 위한 메서드 추가
+    boolean existsByEmail(String email);
+
+    // 4. 회원가입 시 닉네임 중복 체크를 위한 메서드 추가
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/leets/backend/blog/service/AuthService.java
+++ b/src/main/java/com/leets/backend/blog/service/AuthService.java
@@ -1,0 +1,92 @@
+package com.leets.backend.blog.service;
+
+import java.util.Date;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.leets.backend.blog.config.jwt.JwtTokenProvider;
+import com.leets.backend.blog.domain.RefreshToken;
+import com.leets.backend.blog.domain.User;
+import com.leets.backend.blog.dto.TokenInfo;
+import com.leets.backend.blog.dto.UserSignUpRequestDto; // 이 import는 이제 사용되지 않지만, 있어도 문제는 없습니다.
+import com.leets.backend.blog.repository.RefreshTokenRepository;
+import com.leets.backend.blog.repository.UserRepository;
+
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public AuthService(UserRepository userRepository,
+                       PasswordEncoder passwordEncoder,
+                       JwtTokenProvider jwtTokenProvider,
+                       RefreshTokenRepository refreshTokenRepository) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    /**
+     * 회원가입 비즈니스 로직
+     */
+    @Transactional
+    public Long signUp(UserSignUpRequestDto requestDto) {
+        if (userRepository.existsByEmail(requestDto.getEmail())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+        if (userRepository.existsByNickname(requestDto.getNickname())) {
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }
+
+        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+
+        User user = new User();
+        user.setEmail(requestDto.getEmail());
+        user.setPassword(encodedPassword);
+        user.setNickname(requestDto.getNickname());
+
+        User savedUser = userRepository.save(user);
+        return savedUser.getId();
+    }
+
+    /**
+     * 9. 토큰 재발급(reissue) 서비스 메서드 구현
+     * @param requestRefreshToken (String 토큰 값)
+     * @return 갱신된 TokenInfo (새 Access Token + 기존 Refresh Token)
+     */
+    @Transactional
+    public TokenInfo reissueToken(String requestRefreshToken) { // <- 파라미터를 DTO가 아닌 String으로 변경
+
+        // 1. Refresh Token 유효성 검증 (JWT 자체의 유효성)
+        if (!jwtTokenProvider.validateToken(requestRefreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        // 2. DB에서 Refresh Token 조회 (findByToken 메서드 사용)
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(requestRefreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("서버에 존재하지 않는 Refresh Token입니다."));
+
+        // 3. Token에 연동된 User 정보 조회
+        User user = userRepository.findById(refreshToken.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("Token의 사용자 정보가 유효하지 않습니다."));
+
+        // 4. 새로운 Access Token 생성
+        String authorities = user.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+        long now = (new Date()).getTime();
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getEmail(), authorities, now);
+
+        // 5. 새 Access Token과 기존 Refresh Token으로 TokenInfo 반환
+        return TokenInfo.of("Bearer", newAccessToken, requestRefreshToken);
+    }
+}
+

--- a/src/main/java/com/leets/backend/blog/service/AuthService.java
+++ b/src/main/java/com/leets/backend/blog/service/AuthService.java
@@ -12,7 +12,9 @@ import com.leets.backend.blog.config.jwt.JwtTokenProvider;
 import com.leets.backend.blog.domain.RefreshToken;
 import com.leets.backend.blog.domain.User;
 import com.leets.backend.blog.dto.TokenInfo;
-import com.leets.backend.blog.dto.UserSignUpRequestDto; // 이 import는 이제 사용되지 않지만, 있어도 문제는 없습니다.
+import com.leets.backend.blog.dto.UserSignUpRequestDto;
+// [추가] 로그인 DTO import
+import com.leets.backend.blog.dto.UserLoginRequestDto;
 import com.leets.backend.blog.repository.RefreshTokenRepository;
 import com.leets.backend.blog.repository.UserRepository;
 
@@ -58,6 +60,49 @@ public class AuthService {
     }
 
     /**
+     * [추가된 로그인 메소드]
+     * 로그인 비즈니스 로직
+     */
+    @Transactional
+    public TokenInfo login(UserLoginRequestDto requestDto) {
+        // 1. 이메일로 사용자 조회
+        User user = userRepository.findByEmail(requestDto.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+
+        // 2. 비밀번호 일치 여부 확인
+        // (requestDto.getPassword(): 사용자가 입력한 원본 비밀번호, user.getPassword(): DB에 저장된 암호화된 비밀번호)
+        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("잘못된 비밀번호입니다.");
+        }
+
+        // 3. 인증 성공: 토큰 생성
+        // 3-1. 사용자의 권한 정보(roles)를 문자열로 변환 (reissueToken 로직과 동일)
+        String authorities = user.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        // 3-2. Access Token 생성
+        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), authorities, now);
+
+        // 3-3. Refresh Token 생성
+        String refreshToken = jwtTokenProvider.createRefreshToken(now);
+
+        // 4. Refresh Token을 DB에 저장 (사용자 ID와 매핑)
+        //    (기존에 토큰이 있다면 새 토큰으로 덮어쓰기/업데이트)
+        RefreshToken rt = refreshTokenRepository.findByUserId(user.getId())
+                .orElse(new RefreshToken(user.getId())); // 새 RefreshToken 객체 생성 (userId만 설정)
+
+        rt.updateToken(refreshToken); // 새 Refresh Token 값으로 업데이트
+        refreshTokenRepository.save(rt); // DB에 저장 (insert or update)
+
+        // 5. 토큰 정보(TokenInfo) DTO로 반환
+        return TokenInfo.of("Bearer", accessToken, refreshToken);
+    }
+
+
+    /**
      * 9. 토큰 재발급(reissue) 서비스 메서드 구현
      * @param requestRefreshToken (String 토큰 값)
      * @return 갱신된 TokenInfo (새 Access Token + 기존 Refresh Token)
@@ -89,4 +134,3 @@ public class AuthService {
         return TokenInfo.of("Bearer", newAccessToken, requestRefreshToken);
     }
 }
-

--- a/src/main/java/com/leets/backend/blog/service/AuthService.java
+++ b/src/main/java/com/leets/backend/blog/service/AuthService.java
@@ -13,8 +13,11 @@ import com.leets.backend.blog.domain.RefreshToken;
 import com.leets.backend.blog.domain.User;
 import com.leets.backend.blog.dto.TokenInfo;
 import com.leets.backend.blog.dto.UserSignUpRequestDto;
-// [추가] 로그인 DTO import
 import com.leets.backend.blog.dto.UserLoginRequestDto;
+// !! (리뷰 반영) 새로운 커스텀 예외 클래스 임포트 !!
+import com.leets.backend.blog.exception.DuplicateDataException;
+import com.leets.backend.blog.exception.InvalidCredentialsException;
+import com.leets.backend.blog.exception.InvalidTokenException;
 import com.leets.backend.blog.repository.RefreshTokenRepository;
 import com.leets.backend.blog.repository.UserRepository;
 
@@ -41,11 +44,12 @@ public class AuthService {
      */
     @Transactional
     public Long signUp(UserSignUpRequestDto requestDto) {
+        // !! (리뷰 반영) DuplicateDataException으로 수정 !!
         if (userRepository.existsByEmail(requestDto.getEmail())) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+            throw new DuplicateDataException("이미 사용 중인 이메일입니다.");
         }
         if (userRepository.existsByNickname(requestDto.getNickname())) {
-            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+            throw new DuplicateDataException("이미 사용 중인 닉네임입니다.");
         }
 
         String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
@@ -60,42 +64,37 @@ public class AuthService {
     }
 
     /**
-     * [추가된 로그인 메소드]
      * 로그인 비즈니스 로직
      */
     @Transactional
     public TokenInfo login(UserLoginRequestDto requestDto) {
         // 1. 이메일로 사용자 조회
+        // !! (리뷰 반영) InvalidCredentialsException으로 수정 !!
+        // (보안을 위해 "가입되지 않은 이메일"과 "잘못된 비밀번호"를 동일한 예외 메시지로 처리)
         User user = userRepository.findByEmail(requestDto.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+                .orElseThrow(() -> new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."));
 
         // 2. 비밀번호 일치 여부 확인
-        // (requestDto.getPassword(): 사용자가 입력한 원본 비밀번호, user.getPassword(): DB에 저장된 암호화된 비밀번호)
+        // !! (리뷰 반영) InvalidCredentialsException으로 수정 !!
         if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
-            throw new IllegalArgumentException("잘못된 비밀번호입니다.");
+            throw new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.");
         }
 
         // 3. 인증 성공: 토큰 생성
-        // 3-1. 사용자의 권한 정보(roles)를 문자열로 변환 (reissueToken 로직과 동일)
         String authorities = user.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
         long now = (new Date()).getTime();
-
-        // 3-2. Access Token 생성
         String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), authorities, now);
-
-        // 3-3. Refresh Token 생성
         String refreshToken = jwtTokenProvider.createRefreshToken(now);
 
-        // 4. Refresh Token을 DB에 저장 (사용자 ID와 매핑)
-        //    (기존에 토큰이 있다면 새 토큰으로 덮어쓰기/업데이트)
+        // 4. Refresh Token을 DB에 저장
         RefreshToken rt = refreshTokenRepository.findByUserId(user.getId())
-                .orElse(new RefreshToken(user.getId())); // 새 RefreshToken 객체 생성 (userId만 설정)
+                .orElse(new RefreshToken(user.getId()));
 
-        rt.updateToken(refreshToken); // 새 Refresh Token 값으로 업데이트
-        refreshTokenRepository.save(rt); // DB에 저장 (insert or update)
+        rt.updateToken(refreshToken);
+        refreshTokenRepository.save(rt);
 
         // 5. 토큰 정보(TokenInfo) DTO로 반환
         return TokenInfo.of("Bearer", accessToken, refreshToken);
@@ -103,25 +102,27 @@ public class AuthService {
 
 
     /**
-     * 9. 토큰 재발급(reissue) 서비스 메서드 구현
-     * @param requestRefreshToken (String 토큰 값)
-     * @return 갱신된 TokenInfo (새 Access Token + 기존 Refresh Token)
+     * 토큰 재발급(reissue) 서비스 메서드 구현
      */
     @Transactional
-    public TokenInfo reissueToken(String requestRefreshToken) { // <- 파라미터를 DTO가 아닌 String으로 변경
+    public TokenInfo reissueToken(String requestRefreshToken) {
 
-        // 1. Refresh Token 유효성 검증 (JWT 자체의 유효성)
+        // 1. Refresh Token 유효성 검증
+        // !! (리뷰 반영) InvalidTokenException으로 수정 !!
         if (!jwtTokenProvider.validateToken(requestRefreshToken)) {
-            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+            throw new InvalidTokenException("유효하지 않은 Refresh Token입니다.");
         }
 
-        // 2. DB에서 Refresh Token 조회 (findByToken 메서드 사용)
+        // 2. DB에서 Refresh Token 조회
+        // !! (리뷰 반영) InvalidTokenException으로 수정 !!
         RefreshToken refreshToken = refreshTokenRepository.findByToken(requestRefreshToken)
-                .orElseThrow(() -> new IllegalArgumentException("서버에 존재하지 않는 Refresh Token입니다."));
+                .orElseThrow(() -> new InvalidTokenException("서버에 존재하지 않는 Refresh Token입니다."));
 
         // 3. Token에 연동된 User 정보 조회
+        // !! (리뷰 반영) InvalidTokenException으로 수정 !!
+        // (UserNotFoundException을 던질 수도 있지만, "토큰 관련 오류"로 묶어서 401을 반환하는 것이 더 적절함)
         User user = userRepository.findById(refreshToken.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("Token의 사용자 정보가 유효하지 않습니다."));
+                .orElseThrow(() -> new InvalidTokenException("Token의 사용자 정보가 유효하지 않습니다."));
 
         // 4. 새로운 Access Token 생성
         String authorities = user.getAuthorities().stream()

--- a/src/main/java/com/leets/backend/blog/service/CommentService.java
+++ b/src/main/java/com/leets/backend/blog/service/CommentService.java
@@ -1,8 +1,15 @@
 package com.leets.backend.blog.service;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.leets.backend.blog.exception.CommentPermissionException;
+import com.leets.backend.blog.exception.PostNotFoundException;
+import com.leets.backend.blog.exception.UserNotFoundException;
+import com.leets.backend.blog.exception.CommentNotFoundException;
+import com.leets.backend.blog.util.SecurityUtil; // SecurityUtil 임포트
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,30 +38,44 @@ public class CommentService {
         this.userRepository = userRepository;
     }
 
+    // getTemporaryUser() 메서드 삭제됨
+
     // 댓글 등록
     @Transactional
-    public CommentResponse save(Long postId, CommentSaveRequest request, Long currentUserId) {
+    public CommentResponse save(Long postId, CommentSaveRequest request) {
+        // SecurityUtil을 사용하여 현재 사용자 ID를 가져옵니다.
+        // 로그아웃 상태면 "로그인이 필요합니다." 예외 발생
+        Long currentUserId = SecurityUtil.getCurrentUserId()
+                .orElseThrow(() -> new CommentPermissionException("댓글 작성 권한이 없습니다. 로그인이 필요합니다."));
+
         User currentUser = userRepository.findById(currentUserId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserNotFoundException(currentUserId));
 
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글이 없습니다. id=" + postId));
+                .orElseThrow(() -> new PostNotFoundException(postId));
 
         Comment comment = new Comment(request.getContent(), post, currentUser);
         Comment savedComment = commentRepository.save(comment);
 
-        return new CommentResponse(savedComment, true);
+        return new CommentResponse(savedComment, true); // 내가 방금 썼으니 항상 true
     }
 
     // 댓글 조회
     @Transactional(readOnly = true)
-    public List<CommentResponse> findAllByPost(Long postId, Long currentUserId) {
+    public List<CommentResponse> findAllByPost(Long postId) {
+        // SecurityUtil을 사용. 로그아웃 상태일 경우 Optional.empty() 반환
+        Optional<Long> currentUserIdOptional = SecurityUtil.getCurrentUserId();
+        // 로그아웃 상태면 null, 로그인 상태면 userId
+        Long currentUserId = currentUserIdOptional.orElse(null);
+
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글이 없습니다. id=" + postId));
+                .orElseThrow(() -> new PostNotFoundException(postId));
 
         return commentRepository.findByPost(post).stream()
                 .map(comment -> {
-                    boolean isOwner = comment.getUser().getId().equals(currentUserId);
+                    // 로그인 상태이고(currentUserId != null), 댓글 작성자와 ID가 같으면 true
+                    boolean isOwner = (currentUserId != null) &&
+                            (Objects.equals(comment.getUser().getId(), currentUserId));
                     return new CommentResponse(comment, isOwner);
                 })
                 .collect(Collectors.toList());
@@ -62,26 +83,36 @@ public class CommentService {
 
     // 3. 댓글 수정
     @Transactional
-    public CommentResponse update(Long commentId, CommentUpdateRequest request, Long currentUserId) {
+    public CommentResponse update(Long commentId, CommentUpdateRequest request) {
+        // 로그아웃 상태면 "로그인이 필요합니다." 예외 발생
+        Long currentUserId = SecurityUtil.getCurrentUserId()
+                .orElseThrow(() -> new CommentPermissionException("댓글 수정 권한이 없습니다. 로그인이 필요합니다."));
+
         Comment comment = findCommentAndCheckOwnership(commentId, currentUserId);
-        comment.updateContent(request.getContent()); // (Comment 엔티티에 updateContent 메서드 필요)
-        return new CommentResponse(comment, true);
+        comment.updateContent(request.getContent());
+
+        return new CommentResponse(comment, true); // 수정 권한이 있으니 true
     }
 
     // 4. 댓글 삭제
     @Transactional
-    public void delete(Long commentId, Long currentUserId) {
+    public void delete(Long commentId) {
+        // 로그아웃 상태면 "로그인이 필요합니다." 예외 발생
+        Long currentUserId = SecurityUtil.getCurrentUserId()
+                .orElseThrow(() -> new CommentPermissionException("댓글 삭제 권한이 없습니다. 로그인이 필요합니다."));
+
         Comment comment = findCommentAndCheckOwnership(commentId, currentUserId);
         commentRepository.delete(comment);
     }
 
-    //  댓글 조회 및 소유권 검증
+    // 댓글 조회 및 소유권 검증
     private Comment findCommentAndCheckOwnership(Long commentId, Long currentUserId) {
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException("댓글이 없습니다. id=" + commentId));
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
 
-        if (!comment.getUser().getId().equals(currentUserId)) {
-            throw new RuntimeException("댓글 수정/삭제 권한이 없습니다."); 
+        if (!Objects.equals(comment.getUser().getId(), currentUserId)) {
+            // ID가 다르다면 (null 포함) 권한 예외 발생
+            throw new CommentPermissionException(commentId, currentUserId);
         }
         return comment;
     }

--- a/src/main/java/com/leets/backend/blog/service/CommentService.java
+++ b/src/main/java/com/leets/backend/blog/service/CommentService.java
@@ -1,0 +1,88 @@
+package com.leets.backend.blog.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.leets.backend.blog.domain.Comment;
+import com.leets.backend.blog.domain.Post;
+import com.leets.backend.blog.domain.User;
+import com.leets.backend.blog.dto.CommentResponse;
+import com.leets.backend.blog.dto.CommentSaveRequest;
+import com.leets.backend.blog.dto.CommentUpdateRequest;
+import com.leets.backend.blog.repository.CommentRepository;
+import com.leets.backend.blog.repository.PostRepository;
+import com.leets.backend.blog.repository.UserRepository;
+
+@Service
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    public CommentService(CommentRepository commentRepository,
+                          PostRepository postRepository,
+                          UserRepository userRepository) {
+        this.commentRepository = commentRepository;
+        this.postRepository = postRepository;
+        this.userRepository = userRepository;
+    }
+
+    // 댓글 등록
+    @Transactional
+    public CommentResponse save(Long postId, CommentSaveRequest request, Long currentUserId) {
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글이 없습니다. id=" + postId));
+
+        Comment comment = new Comment(request.getContent(), post, currentUser);
+        Comment savedComment = commentRepository.save(comment);
+
+        return new CommentResponse(savedComment, true);
+    }
+
+    // 댓글 조회
+    @Transactional(readOnly = true)
+    public List<CommentResponse> findAllByPost(Long postId, Long currentUserId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글이 없습니다. id=" + postId));
+
+        return commentRepository.findByPost(post).stream()
+                .map(comment -> {
+                    boolean isOwner = comment.getUser().getId().equals(currentUserId);
+                    return new CommentResponse(comment, isOwner);
+                })
+                .collect(Collectors.toList());
+    }
+
+    // 3. 댓글 수정
+    @Transactional
+    public CommentResponse update(Long commentId, CommentUpdateRequest request, Long currentUserId) {
+        Comment comment = findCommentAndCheckOwnership(commentId, currentUserId);
+        comment.updateContent(request.getContent()); // (Comment 엔티티에 updateContent 메서드 필요)
+        return new CommentResponse(comment, true);
+    }
+
+    // 4. 댓글 삭제
+    @Transactional
+    public void delete(Long commentId, Long currentUserId) {
+        Comment comment = findCommentAndCheckOwnership(commentId, currentUserId);
+        commentRepository.delete(comment);
+    }
+
+    //  댓글 조회 및 소유권 검증
+    private Comment findCommentAndCheckOwnership(Long commentId, Long currentUserId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 없습니다. id=" + commentId));
+
+        if (!comment.getUser().getId().equals(currentUserId)) {
+            throw new RuntimeException("댓글 수정/삭제 권한이 없습니다."); 
+        }
+        return comment;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/service/CustomUserDetailsService.java
+++ b/src/main/java/com/leets/backend/blog/service/CustomUserDetailsService.java
@@ -1,0 +1,39 @@
+package com.leets.backend.blog.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.leets.backend.blog.domain.User;
+import com.leets.backend.blog.repository.UserRepository;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    // UserRepository를 주입받음
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * Spring Security가 로그인 인증 시 호출하는 메서드
+     * @param email (로그인 시 사용자가 입력한 이메일)
+     * @return UserDetails (우리의 User 객체)
+     * @throws UsernameNotFoundException
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        // UserRepository를 통해 이메일로 사용자 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 찾을 수 없습니다: " + email));
+
+        // User 객체는 UserDetails를 구현하고 있으므로 그대로 반환
+        // (Spring Security가 이 UserDetails 객체를 받아 비밀번호를 비교함)
+        return user;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/util/SecurityUtil.java
+++ b/src/main/java/com/leets/backend/blog/util/SecurityUtil.java
@@ -1,0 +1,50 @@
+package com.leets.backend.blog.util; // <-- 패키지 경로를 blog.util로 지정
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
+
+public class SecurityUtil {
+
+    private SecurityUtil() {
+    }
+
+    // 현재 인증된 사용자의 ID(Long)를 Optional로 반환합니다.
+    public static Optional<Long> getCurrentUserId() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof UserDetails) {
+            // UserDetails 인터페이스를 사용하는 경우 (일반적)
+            UserDetails userDetails = (UserDetails) principal;
+            // Spring Security는 기본적으로 username(PK)을 String으로 관리합니다.
+            // 이 프로젝트에서는 ID(Long)를 username으로 사용한다고 가정합니다.
+            try {
+                return Optional.of(Long.parseLong(userDetails.getUsername()));
+            } catch (NumberFormatException e) {
+                // username이 Long 타입이 아닌 경우 (예: 이메일)
+                return Optional.empty();
+            }
+        } else if (principal instanceof String) {
+            // principal이 String인 경우 (예: "anonymousUser")
+            if ("anonymousUser".equals(principal)) {
+                return Optional.empty();
+            }
+            // 그 외 String principal (ID일 경우)
+            try {
+                return Optional.of(Long.parseLong((String) principal));
+            } catch (NumberFormatException e) {
+                return Optional.empty();
+            }
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,6 @@ spring:
     show-sql: true
     open-in-view: false
 
-
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
@@ -24,8 +23,18 @@ springdoc:
     version: "v1.0.0"
     description: "블로그 프로젝트 API 명세서입니다."
 
-
+# ==================================
+# JWT (JSON Web Token) 설정
+# ==================================
 jwt:
-  secret: "YOUR_SUPER_SECRET_JWT_KEY_NEEDS_TO_BE_VERY_LONG_AND_SECURE_REPLACE_THIS_NOW"
-  access-token-expiration-ms: 3600000
+  # HMAC-SHA 알고리즘을 위한 비밀키. Base64로 인코딩된 64바이트 이상의 문자열 권장
+  # 예시: (테스트용)
+  secret: "eW91ci1zdXBlci1zdHJvbmctc2VjcmV0LWtleS1iYXNlNjQtZW5jb2RlZA=="
 
+  # Access Token 만료 시간 (밀리초 단위)
+  # 30분 = 30 * 60 * 1000 = 1800000
+  access-token-expiration-ms: 1800000
+
+  # Refresh Token 만료 시간 (밀리초 단위)
+  # 7일 = 7 * 24 * 60 * 60 * 1000 = 604800000
+  refresh-token-expiration-ms: 604800000

--- a/src/test/java/com/leets/backend/blog_manage/blog/BlogManageApplicationTests.java
+++ b/src/test/java/com/leets/backend/blog_manage/blog/BlogManageApplicationTests.java
@@ -1,4 +1,4 @@
-package com.leets.backend.blog;
+package com.leets.backend.blog_manage.blog;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,4 +11,4 @@ class BlogManageApplicationTests {
     }
 
 }
-//주석
+


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

프로젝트에 Spring Security를 도입하고 JWT 기반의 무상태 인증/인가 구조를 구축
이메일 기반의 회원가입, 로그인, 로그아웃 기능을 구현하고, 토큰 전략을 HttpOnly 쿠키 기반으로 변경

config (보안 설정)
- SecurityConfig를 통해 인증/인가 설정
- CSRF 비활성화, 세션 정책 STATELESS로 설정
- JWT 인증을 위한 JwtAuthenticationFilter (토큰 검증)와 JwtLoginFilter (로그인 처리)를 구현하고 SecurityFilterChain에 등록
- 인증/인가 예외 처리 : AuthenticationEntryPoint , AccessDeniedHandler를 구현

auth (회원가입/인증)
- 회원가입 (POST /auth/signup/email): AuthService에서 이메일/닉네임 중복 검증 로직을 구현
- 비밀번호 암호화 (PasswordEncoder Bean 등록)를 적용하여 사용자의 비밀번호를 안전하게 저장
- 로그인 (POST /auth/login/email): JwtLoginFilter를 통해 인증을 처리

jwt
- 로그인 성공 시 JwtTokenProvider를 통해 JWT(Access Token, Refresh Token)를 발급합니다.
- 토큰 전략 (HttpOnly 쿠키 기반): 
  Access Token: 응답 본문(Body)에 포함하여 클라이언트에 전송 
  Refresh Token: HttpOnly 쿠키에 저장
- 로그아웃 (POST /auth/logout): RefreshTokenRepository에서 DB의 Refresh Token을 삭제하고, 클라이언트의 쿠키를 만료시켜 무효화
- RefreshToken 엔티티 및 RefreshTokenRepository를 구현하여 Refresh Token을 서버 DB에서 관리

user (도메인 및 DTO)
- User 엔티티가 UserDetails를 구현
- UserSignUpRequestDto 수정: introduction, birthdate 필드 추가

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

swagger 403 forbidden : webSecurityCustomizer()를 통해 ignoring() 처리하여, Spring Security 필터 체인을 통과하지 않도록 설정
캐쉬 문제로 AuthController 에러
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="2844" height="1493" alt="image" src="https://github.com/user-attachments/assets/9862596c-d5ec-4a2b-ab23-0b21a7276b10" />
<img width="2792" height="1488" alt="image" src="https://github.com/user-attachments/assets/73002893-92a5-4cdc-aa9c-a405ef5834a9" />


<br>

## 4. 완료 사항

1. HttpOnly 쿠키 기반 Refresh Token 관리
2. 회원가입, 로그인, 로그아웃 로직
3. 토큰 생성/검증
4. RefreshToken entity 및 RefreshTokenRepository
5. User entity (UserDetails 구현) 및 UserRepository

<br>

## 5. 추가 사항

closed #101 

<br>