### PR TITLE
[6주차] 김민지 / [feat] 카카오 회원가입 및 로그인 기능 구현

### DIFF
--- a/blog/src/main/java/com/leets/backend/blog/BlogApplication.java
+++ b/blog/src/main/java/com/leets/backend/blog/BlogApplication.java
@@ -2,12 +2,19 @@ package com.leets.backend.blog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class BlogApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(BlogApplication.class, args);
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 
 }

--- a/blog/src/main/java/com/leets/backend/blog/config/KakaoProperties.java
+++ b/blog/src/main/java/com/leets/backend/blog/config/KakaoProperties.java
@@ -1,0 +1,47 @@
+package com.leets.backend.blog.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "kakao")
+public class KakaoProperties {
+
+    private String clientId;
+    private String redirectUri;
+    private String tokenUri;
+    private String userInfoUri;
+
+    // Getters and Setters
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+
+    public void setRedirectUri(String redirectUri) {
+        this.redirectUri = redirectUri;
+    }
+
+    public String getTokenUri() {
+        return tokenUri;
+    }
+
+    public void setTokenUri(String tokenUri) {
+        this.tokenUri = tokenUri;
+    }
+
+    public String getUserInfoUri() {
+        return userInfoUri;
+    }
+
+    public void setUserInfoUri(String userInfoUri) {
+        this.userInfoUri = userInfoUri;
+    }
+}

--- a/blog/src/main/java/com/leets/backend/blog/controller/AuthController.java
+++ b/blog/src/main/java/com/leets/backend/blog/controller/AuthController.java
@@ -70,6 +70,26 @@ public class AuthController {
                 .body(ApiResponse.onSuccess(HttpStatus.OK, "이메일 로그인 성공", responseBody));
     }
 
+    // 카카오 로그인
+    @Operation(summary = "카카오 로그인/회원가입", description = "카카오 인가 코드를 받아 로그인/회원가입 처리 후 JWT 발급합니다.")
+    @GetMapping("/login/kakao")
+    public ResponseEntity<ApiResponse<TokenResponseDTO>> kakaoLogin(
+            @RequestParam("code") String code
+    ) throws AuthException {
+        // 인가 코드로 카카오 로그인/회원가입 처리
+        TokenResponseDTO tokens = authService.loginWithKakao(code);
+
+        // Refresh Token을 HttpOnly 쿠키로 설정
+        ResponseCookie refreshTokenCookie = createRefreshTokenCookie(tokens.getRefreshToken());
+
+        // Access Token만 응답 본문에 포함
+        TokenResponseDTO responseBody = new TokenResponseDTO(tokens.getAccessToken());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(ApiResponse.onSuccess(HttpStatus.OK, "카카오 로그인 성공", responseBody));
+    }
+
     // 로그아웃
     @Operation(summary = "로그아웃", description = "Refresh Token을 만료시킵니다.")
     @PostMapping("/logout")
@@ -81,13 +101,7 @@ public class AuthController {
         authService.logout(refreshToken);
 
         // 클라이언트의 쿠키를 삭제하기 위한 만료 쿠키 직접 생성 (CookieUtil 대체)
-        ResponseCookie clearCookie = ResponseCookie.from("refreshToken", "")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
-                .path("/auth")
-                .maxAge(0) // 즉시 만료
-                .build();
+        ResponseCookie clearCookie = createClearCookie();
 
         // 헤더에 만료 쿠키를 설정하여 응답
         return ResponseEntity.ok()
@@ -107,5 +121,27 @@ public class AuthController {
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(HttpStatus.OK, "액세스 토큰 재발급 성공", responseBody)
         );
+    }
+
+    // Refresh Token 쿠키 생성
+    private ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true) // HTTPS
+                .sameSite("Strict") // CSRF 방어
+                .path("/auth") // 쿠키 사용 경로 제한 (/auth/refresh, /auth/logout)
+                .maxAge(jwtProperties.getRefreshTokenExpirationMs() / 1000) // 만료 시간(초)
+                .build();
+    }
+
+    // 쿠키 클리어
+    private ResponseCookie createClearCookie() {
+        return ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/auth")
+                .maxAge(0) // 즉시 만료
+                .build();
     }
 }

--- a/blog/src/main/java/com/leets/backend/blog/dto/kakao/KakaoAccount.java
+++ b/blog/src/main/java/com/leets/backend/blog/dto/kakao/KakaoAccount.java
@@ -1,0 +1,31 @@
+package com.leets.backend.blog.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KakaoAccount {
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("profile")
+    private Profile profile;
+
+    public KakaoAccount() {}
+
+    // Getters and Setters
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public Profile getProfile() {
+        return profile;
+    }
+
+    public void setProfile(Profile profile) {
+        this.profile = profile;
+    }
+}

--- a/blog/src/main/java/com/leets/backend/blog/dto/kakao/KakaoTokenResponseDTO.java
+++ b/blog/src/main/java/com/leets/backend/blog/dto/kakao/KakaoTokenResponseDTO.java
@@ -1,0 +1,64 @@
+package com.leets.backend.blog.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KakaoTokenResponseDTO {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+
+    public KakaoTokenResponseDTO() {}
+
+    // Getters
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public Integer getExpiresIn() {
+        return expiresIn;
+    }
+
+    public Integer getRefreshTokenExpiresIn() {
+        return refreshTokenExpiresIn;
+    }
+
+    // Setters
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void setExpiresIn(Integer expiresIn) {
+        this.expiresIn = expiresIn;
+    }
+
+    public void setRefreshTokenExpiresIn(Integer refreshTokenExpiresIn) {
+        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
+    }
+}

--- a/blog/src/main/java/com/leets/backend/blog/dto/kakao/KakaoUserInfoResponseDTO.java
+++ b/blog/src/main/java/com/leets/backend/blog/dto/kakao/KakaoUserInfoResponseDTO.java
@@ -1,0 +1,30 @@
+package com.leets.backend.blog.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KakaoUserInfoResponseDTO {
+    @JsonProperty("id")
+    private Long id; // 카카오 고유 ID
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    public KakaoUserInfoResponseDTO() {}
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public KakaoAccount getKakaoAccount() {
+        return kakaoAccount;
+    }
+
+    public void setKakaoAccount(KakaoAccount kakaoAccount) {
+        this.kakaoAccount = kakaoAccount;
+    }
+}

--- a/blog/src/main/java/com/leets/backend/blog/dto/kakao/Profile.java
+++ b/blog/src/main/java/com/leets/backend/blog/dto/kakao/Profile.java
@@ -1,0 +1,30 @@
+package com.leets.backend.blog.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Profile {
+    @JsonProperty("nickname")
+    private String nickname;
+
+    @JsonProperty("profile_image_url")
+    private String profileImageUrl;
+
+    public Profile() {}
+
+    // Getters and Setters
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+
+    public void setProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/blog/src/main/java/com/leets/backend/blog/entity/User.java
+++ b/blog/src/main/java/com/leets/backend/blog/entity/User.java
@@ -1,5 +1,6 @@
 package com.leets.backend.blog.entity;
 
+import com.leets.backend.blog.dto.kakao.KakaoAccount;
 import com.leets.backend.blog.enums.LoginMethod;
 import jakarta.persistence.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -58,6 +59,39 @@ public class User implements UserDetails {
         this.birthdate = birthdate;
         this.roles = (roles == null || roles.isEmpty()) ? "ROLE_USER" : roles;
         this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 카카오 회원가입용
+    public static User createKakaoUser(String kakaoId, String email, String name, String nickname, String profileImageUrl) {
+        User user = new User();
+        user.kakaoId = kakaoId;
+        user.email = email;
+
+        // 카카오 닉네임을 임시로 저장
+        user.name = name;
+        user.nickname = nickname;
+
+        user.profileImage = profileImageUrl;
+        user.loginMethod = LoginMethod.KAKAO;
+        user.roles = "ROLE_USER";
+        user.createdAt = LocalDateTime.now();
+        user.updatedAt = LocalDateTime.now();
+        user.password = null; // 카카오 유저는 비밀번호 없음
+
+        return user;
+    }
+
+    // 카카오 정보로 프로필 업데이트
+    public void updateKakaoProfile(KakaoAccount kakaoAccount) {
+        if (kakaoAccount.getProfile() != null) {
+            this.nickname = kakaoAccount.getProfile().getNickname();
+            this.profileImage = kakaoAccount.getProfile().getProfileImageUrl();
+        }
+        if (kakaoAccount.getEmail() != null) {
+            this.email = kakaoAccount.getEmail();
+        }
+
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/blog/src/main/java/com/leets/backend/blog/exception/auth/ErrorCode.java
+++ b/blog/src/main/java/com/leets/backend/blog/exception/auth/ErrorCode.java
@@ -15,7 +15,10 @@ public enum ErrorCode {
 
     // Spring Security
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    // 428 Precondition Required (새로운 에러 코드)
+    KAKAO_EMAIL_NOT_CONSENTED(HttpStatus.PRECONDITION_REQUIRED, "카카오 로그인 시 이메일 동의는 필수입니다. 다시 시도해 주세요.");
 
     private final HttpStatus status;
     private final String message;

--- a/blog/src/main/java/com/leets/backend/blog/repository/UserRepository.java
+++ b/blog/src/main/java/com/leets/backend/blog/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByKakaoId(String kakaoId);
 }

--- a/blog/src/main/java/com/leets/backend/blog/service/AuthService.java
+++ b/blog/src/main/java/com/leets/backend/blog/service/AuthService.java
@@ -96,7 +96,7 @@ public class AuthService {
         RefreshToken refreshToken = new RefreshToken(
                 user,
                 refreshTokenString,
-                LocalDateTime.now().plusNanos(refreshTokenExpirationMs / 1000) // ms to ns and add
+                LocalDateTime.now().plusNanos(refreshTokenExpirationMs * 1000) // ms to ns and add
         );
         refreshTokenRepository.save(refreshToken);
 
@@ -167,7 +167,7 @@ public class AuthService {
         RefreshToken refreshToken = new RefreshToken(
                 user,
                 refreshTokenString,
-                LocalDateTime.now().plusNanos(refreshTokenExpirationMs / 1000)
+                LocalDateTime.now().plusNanos(refreshTokenExpirationMs * 1000)
         );
         refreshTokenRepository.save(refreshToken);
 

--- a/blog/src/main/java/com/leets/backend/blog/service/AuthService.java
+++ b/blog/src/main/java/com/leets/backend/blog/service/AuthService.java
@@ -4,6 +4,9 @@ import com.leets.backend.blog.config.JwtTokenProvider;
 import com.leets.backend.blog.dto.LoginRequestDTO;
 import com.leets.backend.blog.dto.SignUpRequestDTO;
 import com.leets.backend.blog.dto.TokenResponseDTO;
+import com.leets.backend.blog.dto.kakao.KakaoAccount;
+import com.leets.backend.blog.dto.kakao.KakaoTokenResponseDTO;
+import com.leets.backend.blog.dto.kakao.KakaoUserInfoResponseDTO;
 import com.leets.backend.blog.entity.RefreshToken;
 import com.leets.backend.blog.entity.User;
 import com.leets.backend.blog.enums.LoginMethod;
@@ -31,14 +34,18 @@ public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
     private final long refreshTokenExpirationMs;
+    private final KakaoOAuthService kakaoOAuthService;
 
-    public AuthService(UserRepository userRepository, RefreshTokenRepository refreshTokenRepository, PasswordEncoder passwordEncoder, @Lazy AuthenticationManager authenticationManager, JwtTokenProvider jwtTokenProvider, com.leets.backend.blog.config.JwtProperties jwtProperties) {
+
+    public AuthService(UserRepository userRepository, RefreshTokenRepository refreshTokenRepository, PasswordEncoder passwordEncoder, @Lazy AuthenticationManager authenticationManager, JwtTokenProvider jwtTokenProvider, com.leets.backend.blog.config.JwtProperties jwtProperties
+    ,KakaoOAuthService kakaoOAuthService) {
         this.userRepository = userRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.passwordEncoder = passwordEncoder;
         this.authenticationManager = authenticationManager;
         this.jwtTokenProvider = jwtTokenProvider;
         this.refreshTokenExpirationMs = jwtProperties.getRefreshTokenExpirationMs();
+        this.kakaoOAuthService = kakaoOAuthService;
     }
 
     // 이메일 회원가입
@@ -94,6 +101,88 @@ public class AuthService {
         refreshTokenRepository.save(refreshToken);
 
         return new TokenResponseDTO(accessToken, refreshTokenString);
+    }
+
+    // 카카오 로그인/회원가입
+    public TokenResponseDTO loginWithKakao(String code) throws AuthException {
+        // 카카오 서버로부터 사용자 정보 획득
+        KakaoTokenResponseDTO kakaoToken = kakaoOAuthService.getKakaoToken(code);
+        KakaoUserInfoResponseDTO userInfo = kakaoOAuthService.getKakaoUserInfo(kakaoToken.getAccessToken());
+
+        String kakaoId = userInfo.getId().toString();
+        KakaoAccount kakaoAccount = userInfo.getKakaoAccount();
+
+        String email = kakaoAccount.getEmail();
+        if (email == null) {
+            throw new AuthException(String.valueOf(ErrorCode.KAKAO_EMAIL_NOT_CONSENTED));
+        }
+
+        // 카카오 ID로 DB에서 사용자 조회
+        User user = userRepository.findByKakaoId(kakaoId)
+                .map(existingUser -> {
+                    // 기존 사용자인 경우: 정보 업데이트
+                    existingUser.updateKakaoProfile(kakaoAccount);
+                    return existingUser;
+                })
+                .orElseGet(() -> {
+                    // 신규 사용자인 경우: 회원가입
+                    // 이메일 중복 체크 (로컬 계정과 중복될 경우)
+                    if (userRepository.existsByEmail(email)) {
+                        try {
+                            throw new AuthException(String.valueOf(ErrorCode.EMAIL_ALREADY_EXISTS));
+                        } catch (AuthException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    // name 필드
+                    String lastDigits = kakaoId.substring(Math.max(0, kakaoId.length() - 6));
+                    String tempName = "K_" + lastDigits; // 예: K_386990 (총 8자)
+                    // ---------------------------------
+
+                    // 닉네임 처리
+                    String kakaoNickname = kakaoAccount.getProfile() != null ? kakaoAccount.getProfile().getNickname() : null;
+                    // 닉네임이 없으면 카카오 ID 기반으로 임시 닉네임 생성
+                    String baseNickname = (kakaoNickname != null && !kakaoNickname.isEmpty()) ? kakaoNickname : "user_" + kakaoId;
+
+                    // 고유 닉네임 확보
+                    String uniqueNickname = getUniqueNickname(baseNickname);
+
+                    String profileImageUrl = kakaoAccount.getProfile() != null ? kakaoAccount.getProfile().getProfileImageUrl() : null;
+
+                    User newUser = User.createKakaoUser(kakaoId, email, tempName, uniqueNickname, profileImageUrl);
+                    return userRepository.save(newUser);
+                });
+
+        // JWT 발급
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                user.getEmail(), null, user.getAuthorities()
+        );
+
+        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+        String refreshTokenString = jwtTokenProvider.createRefreshToken(authentication);
+
+        // Refresh Token DB 저장
+        refreshTokenRepository.deleteByUser(user);
+        RefreshToken refreshToken = new RefreshToken(
+                user,
+                refreshTokenString,
+                LocalDateTime.now().plusNanos(refreshTokenExpirationMs / 1000)
+        );
+        refreshTokenRepository.save(refreshToken);
+
+        return new TokenResponseDTO(accessToken, refreshTokenString);
+    }
+
+    private String getUniqueNickname(String nickname) {
+        String uniqueNickname = nickname;
+        int suffix = 1;
+        // DB에 중복된 닉네임이 없을 때까지 반복
+        while (userRepository.existsByNickname(uniqueNickname)) {
+            uniqueNickname = nickname + "_" + suffix;
+            suffix++;
+        }
+        return uniqueNickname;
     }
 
     // 로그아웃

--- a/blog/src/main/java/com/leets/backend/blog/service/KakaoOAuthService.java
+++ b/blog/src/main/java/com/leets/backend/blog/service/KakaoOAuthService.java
@@ -1,0 +1,60 @@
+package com.leets.backend.blog.service;
+
+import com.leets.backend.blog.config.KakaoProperties;
+import com.leets.backend.blog.dto.kakao.KakaoTokenResponseDTO;
+import com.leets.backend.blog.dto.kakao.KakaoUserInfoResponseDTO;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class KakaoOAuthService {
+
+    private final KakaoProperties kakaoProperties;
+    private final RestTemplate restTemplate;
+
+    public KakaoOAuthService(KakaoProperties kakaoProperties, RestTemplate restTemplate) {
+        this.kakaoProperties = kakaoProperties;
+        this.restTemplate = restTemplate;
+    }
+
+    // 인가 코드로 카카오 액세스 토큰 받기
+    public KakaoTokenResponseDTO getKakaoToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoProperties.getClientId());
+        params.add("redirect_uri", kakaoProperties.getRedirectUri());
+        params.add("code", code);
+
+        org.springframework.http.HttpEntity<MultiValueMap<String, String>> request =
+                new org.springframework.http.HttpEntity<>(params, headers);
+
+        return restTemplate.postForObject(
+                kakaoProperties.getTokenUri(),
+                request,
+                KakaoTokenResponseDTO.class
+        );
+    }
+
+    // 카카오 액세스 토큰으로 사용자 정보 받기
+    public KakaoUserInfoResponseDTO getKakaoUserInfo(String kakaoAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(kakaoAccessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        org.springframework.http.HttpEntity<Void> request =
+                new org.springframework.http.HttpEntity<>(headers);
+
+        return restTemplate.postForObject(
+                kakaoProperties.getUserInfoUri(),
+                request,
+                KakaoUserInfoResponseDTO.class
+        );
+    }
+}

--- a/blog/src/main/resources/application.yml
+++ b/blog/src/main/resources/application.yml
@@ -30,3 +30,10 @@ jwt:
   secret: "W2Bxf8LRrTei5thxLZbG4cQi/lDeXogj9P3n+FJmNRga8WHiRdph1F9o/lLQT7epnovSQGMfAsmwX4UngWp+ng=="
   access-token-expiration-ms: 3600000  # 1시간
   refresh-token-expiration-ms: 604800000 # 7일
+
+# Kakao
+kakao:
+  client-id: 1000bf8964ec857718ba58aceba1c155
+  redirect-uri: http://localhost:8080/auth/login/kakao
+  token-uri: https://kauth.kakao.com/oauth/token
+  user-info-uri: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
OAuth 2.0 기반 카카오 로그인 및 회원가입 기능을 추가하여 사용자 인증 방법을 확장했습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?
1. `Column 'name' cannot be null`
- **원인**: 카카오 로그인 시 필수 동의 항목만 설정했기 때문에, DB 필수 필드인 name에 null 값이 전달되어 발생했습니다.
- **해결**: 카카오로부터 name 값을 받을 수 없으므로, kakao_id를 기반으로 한 임시 값(예: K_123456)을 생성하여 DB의 NOT NULL 제약 조건을 만족시키도록 AuthService 로직을 수정했습니다.

<br>

## 3. 관련 스크린샷을 첨부해주세요.
**- 신규 사용자 가입 및 로그인**
<img width="1280" height="728" alt="카카오회원가입1" src="https://github.com/user-attachments/assets/013e7c47-c046-4451-a66a-f0b919965a41" />

**- 디비 저장**
<img width="1058" height="106" alt="디비" src="https://github.com/user-attachments/assets/f87db695-b5b0-4039-a506-207c17055e4a" />

**- 기존 사용자 로그인**
(1)
<img width="1280" height="116" alt="카카오로그인1" src="https://github.com/user-attachments/assets/e108664e-20b4-4d47-9754-13540de348b3" />
(2)
<img width="751" height="541" alt="카카오로그인2" src="https://github.com/user-attachments/assets/933227a3-bac0-44e0-aac2-7d993679f69a" />

<br>

## 4. 완료 사항
- OAuth 2.0 기반 카카오 회원가입/로그인 기능 구현 완료
- 카카오 인증 플로우 (인가 코드 획득, 토큰 교환, 사용자 정보 조회) 로직 구축
- 카카오 ID 기반으로 사용자를 식별하고 JWT 토큰 발급

<br>

## 5. 추가 사항
closed #107 

<br>