### PR TITLE
[6주차] 김지민/ [feat] 카카오 로그인 구현

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -22,9 +22,14 @@ springdoc:
     operationsSorter: method
     tagsSorter: alpha
 
+kakao:
+  oauth:
+    client-id: 832cf040e50187a709811294587535ee
+    client-secret: STyTYjHaJyNFryjqlbjSK6fdKmoLrEsj
+    redirect-uri: http://localhost:8080/auth/kakao/callback
 
 security:
   jwt:
     secret: g7Wn9vKzE9f3HqV4zD0OErfYh8cKq6LxT0ZzB+Q8m9GfHkP7d9Sxv2Aq9rV1p3Wn==
     access-exp: 1800
-    refresh-exp: 1209600
+    refresh-exp: 120

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0' //스웨거
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.test{

--- a/src/main/java/com/leets/backend/blog/auth/KakaoOAuthClient.java
+++ b/src/main/java/com/leets/backend/blog/auth/KakaoOAuthClient.java
@@ -1,0 +1,188 @@
+package com.leets.backend.blog.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Component
+public class KakaoOAuthClient {
+
+    private static final URI TOKEN_URI = URI.create("https://kauth.kakao.com/oauth/token");
+    private static final URI USER_URI = URI.create("https://kapi.kakao.com/v2/user/me");
+
+    private final RestTemplate restTemplate;
+    private final String clientId;
+    private final String clientSecret;
+    private final String redirectUri;
+
+    public KakaoOAuthClient(RestTemplateBuilder restTemplateBuilder,
+                            @Value("${kakao.oauth.client-id}") String clientId,
+                            @Value("${kakao.oauth.client-secret:}") String clientSecret,
+                            @Value("${kakao.oauth.redirect-uri}") String redirectUri) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUri = redirectUri;
+    }
+
+    public KakaoOAuthTokenResponse exchangeCodeForToken(String authorizationCode) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", "authorization_code");
+        form.add("client_id", clientId);
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            form.add("client_secret", clientSecret);
+        }
+        form.add("redirect_uri", redirectUri);
+        form.add("code", authorizationCode);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(form, headers);
+
+        ResponseEntity<KakaoOAuthTokenResponse> response = restTemplate.postForEntity(
+                TOKEN_URI,
+                entity,
+                KakaoOAuthTokenResponse.class
+        );
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new IllegalStateException("카카오 토큰 발급에 실패했습니다.");
+        }
+        return response.getBody();
+    }
+
+    public KakaoUserProfile fetchUserProfile(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
+                USER_URI,
+                HttpMethod.GET,
+                entity,
+                KakaoUserResponse.class
+        );
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new IllegalStateException("카카오 사용자 정보를 불러오지 못했습니다.");
+        }
+
+        KakaoUserResponse body = response.getBody();
+        String kakaoId = body.getId() != null ? String.valueOf(body.getId()) : null;
+        KakaoAccount account = body.getAccount();
+        String email = null;
+        String nickname = null;
+        String name = null;
+        String profileImage = null;
+        if (account != null) {
+            email = account.getEmail();
+            KakaoProfile profile = account.getProfile();
+            if (profile != null) {
+                nickname = profile.getNickname();
+                profileImage = profile.getProfileImageUrl();
+                name = profile.getNickname();
+            }
+        }
+
+        if (kakaoId == null) {
+            throw new IllegalStateException("카카오 ID를 확인할 수 없습니다.");
+        }
+
+        return new KakaoUserProfile(kakaoId, email, nickname, profileImage, name);
+    }
+
+    private static class KakaoUserResponse {
+        @JsonProperty("id")
+        private Long id;
+
+        @JsonProperty("kakao_account")
+        private KakaoAccount account;
+
+        public KakaoUserResponse() {
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public KakaoAccount getAccount() {
+            return account;
+        }
+
+        public void setAccount(KakaoAccount account) {
+            this.account = account;
+        }
+    }
+
+    private static class KakaoAccount {
+        @JsonProperty("email")
+        private String email;
+
+        @JsonProperty("profile")
+        private KakaoProfile profile;
+
+        public KakaoAccount() {
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public KakaoProfile getProfile() {
+            return profile;
+        }
+
+        public void setProfile(KakaoProfile profile) {
+            this.profile = profile;
+        }
+    }
+
+    private static class KakaoProfile {
+        @JsonProperty("nickname")
+        private String nickname;
+
+        @JsonProperty("profile_image_url")
+        private String profileImageUrl;
+
+        public KakaoProfile() {
+        }
+
+        public String getNickname() {
+            return nickname;
+        }
+
+        public void setNickname(String nickname) {
+            this.nickname = nickname;
+        }
+
+        public String getProfileImageUrl() {
+            return profileImageUrl;
+        }
+
+        public void setProfileImageUrl(String profileImageUrl) {
+            this.profileImageUrl = profileImageUrl;
+        }
+    }
+}

--- a/src/main/java/com/leets/backend/blog/auth/KakaoOAuthTokenResponse.java
+++ b/src/main/java/com/leets/backend/blog/auth/KakaoOAuthTokenResponse.java
@@ -1,0 +1,53 @@
+package com.leets.backend.blog.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KakaoOAuthTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+
+    public KakaoOAuthTokenResponse() {
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
+
+    public Long getExpiresIn() {
+        return expiresIn;
+    }
+
+    public void setExpiresIn(Long expiresIn) {
+        this.expiresIn = expiresIn;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/auth/KakaoUserProfile.java
+++ b/src/main/java/com/leets/backend/blog/auth/KakaoUserProfile.java
@@ -1,0 +1,41 @@
+package com.leets.backend.blog.auth;
+
+public class KakaoUserProfile {
+    private final String kakaoId;
+    private final String email;
+    private final String nickname;
+    private final String profileImageUrl;
+    private final String name;
+
+    public KakaoUserProfile(String kakaoId,
+                            String email,
+                            String nickname,
+                            String profileImageUrl,
+                            String name) {
+        this.kakaoId = kakaoId;
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.name = name;
+    }
+
+    public String getKakaoId() {
+        return kakaoId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/controller/AuthController.java
+++ b/src/main/java/com/leets/backend/blog/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.leets.backend.blog.dto.LoginRequest;
 import com.leets.backend.blog.dto.LoginResponse;
 import com.leets.backend.blog.dto.SignupRequest;
 import com.leets.backend.blog.service.AuthService;
+import com.leets.backend.blog.dto.KakaoLoginRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,6 +30,11 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest req) {
         return ResponseEntity.ok(authService.login(req));
+    }
+
+    @PostMapping("/kakao")
+    public ResponseEntity<LoginResponse> loginWithKakao(@Valid @RequestBody KakaoLoginRequest req) {
+        return ResponseEntity.ok(authService.loginWithKakao(req));
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/leets/backend/blog/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/leets/backend/blog/dto/KakaoLoginRequest.java
@@ -1,0 +1,23 @@
+package com.leets.backend.blog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class KakaoLoginRequest {
+    @NotBlank
+    private String authorizationCode;
+
+    public KakaoLoginRequest() {
+    }
+
+    public KakaoLoginRequest(String authorizationCode) {
+        this.authorizationCode = authorizationCode;
+    }
+
+    public String getAuthorizationCode() {
+        return authorizationCode;
+    }
+
+    public void setAuthorizationCode(String authorizationCode) {
+        this.authorizationCode = authorizationCode;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/entity/User.java
+++ b/src/main/java/com/leets/backend/blog/entity/User.java
@@ -62,12 +62,87 @@ public class User {
         u.createdAt = LocalDateTime.now();
         return u;
     }
-    public Long getId(){return id;}
-    public String getAuthIdentities(){return authIdentities;}
-    public String getEmail(){return email;}
-    public String getPas() {return pas;}
-    public String getName(){return name;}
-    public LocalDate getBirth(){return birth;}
+
+    public static User createKakao(String kakaoId,
+                                   String email,
+                                   String encodedPassword,
+                                   String nickname,
+                                   String name,
+                                   String profileImage) {
+        User u = new User();
+        u.authIdentities = "kakao";
+        u.kakaoId = kakaoId;
+        u.email = email;
+        u.pas = encodedPassword;
+        u.nick = nickname;
+        u.name = name;
+        u.profileImage = profileImage;
+        u.createdAt = LocalDateTime.now();
+        return u;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getAuthIdentities() {
+        return authIdentities;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPas() {
+        return pas;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public LocalDate getBirth() {
+        return birth;
+    }
+
+    public String getNick() {
+        return nick;
+    }
+
+    public String getProfileImage() {
+        return profileImage;
+    }
+
+    public String getKakaoId() {
+        return kakaoId;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void updateKakaoProfile(String email,
+                                   String nickname,
+                                   String name,
+                                   String profileImage) {
+        if (email != null && !email.isBlank()) {
+            this.email = email;
+        }
+        if (nickname != null && !nickname.isBlank()) {
+            this.nick = nickname;
+        }
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        if (profileImage != null && !profileImage.isBlank()) {
+            this.profileImage = profileImage;
+        }
+        this.updatedAt = LocalDateTime.now();
+    }
 
 
 }

--- a/src/main/java/com/leets/backend/blog/repository/UserRepository.java
+++ b/src/main/java/com/leets/backend/blog/repository/UserRepository.java
@@ -10,6 +10,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByNick(String nick);
     boolean existsByEmail(String email);
+
+    Optional<User> findTopByOrderByIdAsc();
+    Optional<User> findByKakaoId(String kakaoId);
 }
 
 

--- a/src/main/java/com/leets/backend/blog/service/AuthService.java
+++ b/src/main/java/com/leets/backend/blog/service/AuthService.java
@@ -1,9 +1,13 @@
 package com.leets.backend.blog.service;
 
 import com.leets.backend.blog.auth.JwtTokenProvider;
+import com.leets.backend.blog.auth.KakaoOAuthClient;
+import com.leets.backend.blog.auth.KakaoOAuthTokenResponse;
+import com.leets.backend.blog.auth.KakaoUserProfile;
 import com.leets.backend.blog.dto.LoginRequest;
 import com.leets.backend.blog.dto.LoginResponse;
 import com.leets.backend.blog.dto.SignupRequest;
+import com.leets.backend.blog.dto.KakaoLoginRequest;
 import com.leets.backend.blog.entity.Token;
 import com.leets.backend.blog.entity.User;
 import com.leets.backend.blog.repository.*;
@@ -21,15 +25,18 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtProvider; // 네가 쓰는 구현 재사용
     private final TokenService tokenService;
+    private final KakaoOAuthClient kakaoOAuthClient;
 
     public AuthService(UserRepository userRepository,
                        PasswordEncoder passwordEncoder,
                        JwtTokenProvider jwtProvider,
-                       TokenService tokenService) {
+                       TokenService tokenService,
+                       KakaoOAuthClient kakaoOAuthClient) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtProvider = jwtProvider;
         this.tokenService = tokenService;
+        this.kakaoOAuthClient = kakaoOAuthClient;
     }
 
 
@@ -60,6 +67,62 @@ public class AuthService {
         String refreshTokenPlain = tokenService.issueRefreshToken(user);
 
         return new LoginResponse(accessToken, refreshTokenPlain);
+    }
+
+    public LoginResponse loginWithKakao(KakaoLoginRequest request) {
+        KakaoOAuthTokenResponse tokenResponse = kakaoOAuthClient.exchangeCodeForToken(request.getAuthorizationCode());
+        KakaoUserProfile profile = kakaoOAuthClient.fetchUserProfile(tokenResponse.getAccessToken());
+
+        User user = userRepository.findByKakaoId(profile.getKakaoId())
+                .map(existing -> {
+                    existing.updateKakaoProfile(
+                            profile.getEmail(),
+                            profile.getNickname(),
+                            profile.getName(),
+                            profile.getProfileImageUrl()
+                    );
+                    return existing;
+                })
+                .orElseGet(() -> registerKakaoUser(profile));
+
+        String subject = user.getEmail();
+        if (subject == null || subject.isBlank()) {
+            subject = "kakao:" + user.getKakaoId();
+        }
+
+        String accessToken = jwtProvider.createAccessToken(subject);
+        String refreshTokenPlain = tokenService.issueRefreshToken(user);
+
+        return new LoginResponse(accessToken, refreshTokenPlain);
+    }
+
+    private User registerKakaoUser(KakaoUserProfile profile) {
+        String email = profile.getEmail();
+        if (email == null || email.isBlank()) {
+            email = "kakao-" + profile.getKakaoId() + "@oauth.local";
+        }
+
+        String nickname = profile.getNickname();
+        if (nickname == null || nickname.isBlank()) {
+            nickname = "kakao_" + profile.getKakaoId();
+        }
+
+        String name = profile.getName();
+        if (name == null || name.isBlank()) {
+            name = nickname;
+        }
+
+        String randomPassword = passwordEncoder.encode("kakao-" + profile.getKakaoId() + "-" + System.nanoTime());
+
+        User user = User.createKakao(
+                profile.getKakaoId(),
+                email,
+                randomPassword,
+                nickname,
+                name,
+                profile.getProfileImageUrl()
+        );
+        return userRepository.save(user);
     }
 
     public String refreshAccess(String refreshPlain) {


### PR DESCRIPTION
### 주요 변경 사항
- `application.yml`에 카카오 OAuth 자격 정보 추가
- 카카오 인가코드 교환과 사용자 정보 조회를 담당하는 클라이언트 및 토큰/프로필 DTO를 정의
- `AuthService`와` AuthController`, User 엔티티/레포지토리를 확장해 카카오 로그인 사용자 생성/갱신과 JWT 발급 흐름을 완성
- 동작 방식:
  - 프론트엔드에서 카카오 인가 코드 획득 후 /auth/kakao로 전송
  - 서버가 카카오 OAuth 서버로부터 토큰/유저 정보 요청
  - 신규 유저라면 자동 가입, 기존 유저라면 프로필 업데이트
  - JWT Access/Refresh 토큰 발급 후 응답

### 관련 스크린샷
<img width="2016" height="1301" alt="스크린샷 2025-11-11 182608" src="https://github.com/user-attachments/assets/605e7a20-d5f7-4ebb-af67-3aa21a6d99eb" />
<img width="1565" height="1198" alt="스크린샷 2025-11-11 182702" src="https://github.com/user-attachments/assets/9549b097-430c-409b-bdfa-c1ce6ad2f66d" />
<img width="1330" height="142" alt="스크린샷 2025-11-11 195217" src="https://github.com/user-attachments/assets/f35a776c-64d8-494c-9c00-56118b57e81c" />

### 관련 이슈
closed #117