### PR TITLE
[6주차] 박소윤/[feat] 카카오 로그인 및 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.6'
-    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.springframework.boot' version '3.3.1' // 최신 안정 버전으로 조정
+    id 'io.spring.dependency-management' version '1.1.5' // 버전 조정
     id 'org.cyclonedx.bom' version '2.3.0'
 }
 
@@ -20,20 +20,34 @@ repositories {
 }
 
 dependencies {
+    // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // Spring Security 기본 기능
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    testImplementation 'org.springframework.security:spring-security-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // ⭐ 카카오 로그인 (OAuth 2.0) 구현을 위한 필수 의존성 추가 ⭐
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // Data (JPA, MySQL)
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
-    // JJWT: JWT(JSON Web Token)를 생성하고 검증하기 위한 라이브러리
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // OpenAPI/Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0' // 최신 안정 버전으로 조정
+
+    // JWT (JJWT)
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
+++ b/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
@@ -1,23 +1,27 @@
 package com.leets.backend.blog.config;
 
+import com.leets.backend.blog.config.jwt.JwtAuthenticationFilter;
+import com.leets.backend.blog.config.jwt.JwtLoginFilter;
+import com.leets.backend.blog.config.jwt.JwtTokenProvider;
+import com.leets.backend.blog.repository.RefreshTokenRepository;
+import com.leets.backend.blog.service.CustomOAuth2UserService;
+import com.leets.backend.blog.config.oauth.OAuth2AuthenticationSuccessHandler;
+import com.leets.backend.blog.repository.UserRepository;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.authentication.AuthenticationManager; // 1. RefreshTokenRepository import 추가
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+// 1. [삭제] WebSecurityCustomizer Import 제거
+// import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
-import com.leets.backend.blog.config.jwt.JwtAuthenticationFilter;
-import com.leets.backend.blog.config.jwt.JwtLoginFilter;
-import com.leets.backend.blog.config.jwt.JwtTokenProvider;
-import com.leets.backend.blog.repository.RefreshTokenRepository;
 
 @Configuration
 @EnableWebSecurity
@@ -25,7 +29,9 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationConfiguration authenticationConfiguration;
-    private final RefreshTokenRepository refreshTokenRepository; // 2. Repository 필드 추가
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final UserRepository userRepository;
 
     private static final String[] SWAGGER_PATHS = {
             "/v3/api-docs/**",
@@ -33,59 +39,87 @@ public class SecurityConfig {
             "/swagger-ui.html"
     };
 
-    // 3. 생성자 수정 (RefreshTokenRepository 주입)
+    // (생성자는 동일)
     public SecurityConfig(JwtTokenProvider jwtTokenProvider,
                           AuthenticationConfiguration authenticationConfiguration,
-                          RefreshTokenRepository refreshTokenRepository) { // 3. 주입 받기
+                          RefreshTokenRepository refreshTokenRepository,
+                          CustomOAuth2UserService customOAuth2UserService,
+                          UserRepository userRepository) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.authenticationConfiguration = authenticationConfiguration;
-        this.refreshTokenRepository = refreshTokenRepository; // 3. 초기화
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.customOAuth2UserService = customOAuth2UserService;
+        this.userRepository = userRepository;
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-    
+
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
     }
 
+    // 2. [삭제] WebSecurityCustomizer Bean 제거
+    /*
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring()
                 .requestMatchers("/favicon.ico")
                 .requestMatchers(SWAGGER_PATHS)
-                .requestMatchers("/error"); 
+                .requestMatchers("/error");
     }
+    */
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        
+
         AuthenticationManager authenticationManager = authenticationManager(authenticationConfiguration);
 
-        // 4. [수정] JwtLoginFilter 인스턴스 생성 시 Repository 주입
         JwtLoginFilter jwtLoginFilter = new JwtLoginFilter(
-                authenticationManager, 
-                jwtTokenProvider, 
-                refreshTokenRepository // 4. Repository 전달
+                authenticationManager,
+                jwtTokenProvider,
+                refreshTokenRepository
         );
         jwtLoginFilter.setFilterProcessesUrl("/login");
 
+        OAuth2AuthenticationSuccessHandler oAuth2SuccessHandler =
+                new OAuth2AuthenticationSuccessHandler(jwtTokenProvider, refreshTokenRepository, userRepository);
+
         http
-            .csrf(csrf -> csrf.disable())
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(authz -> authz
-                    
-                    .requestMatchers("/auth/**", "/login").permitAll() 
-                    .requestMatchers(HttpMethod.GET, "/posts", "/posts/**").permitAll()
-                    .anyRequest().authenticated() 
-            )
-            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
-            .addFilterAt(jwtLoginFilter, UsernamePasswordAuthenticationFilter.class);
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
+                        )
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureUrl("/loginFailure")
+                )
+
+                // 3. [수정] authorizeHttpRequests를 한 곳에서 관리
+                .authorizeHttpRequests(authz -> authz
+                        // 3-1. (추가) 기존 WebSecurityCustomizer에 있던 경로들
+                        .requestMatchers("/favicon.ico").permitAll()
+                        .requestMatchers(SWAGGER_PATHS).permitAll()
+                        .requestMatchers("/error").permitAll()
+
+                        // 3-2. (기존) OAuth2 및 JWT 관련 경로들
+                        .requestMatchers("/auth/**", "/login").permitAll()
+                        .requestMatchers("/login/oauth2/code/**").permitAll()
+
+                        // 3-3. (기존) GET 요청 허용 경로
+                        .requestMatchers(HttpMethod.GET, "/posts", "/posts/**").permitAll()
+
+                        // 3-4. (기존) 나머지 모든 요청은 인증 필요
+                        .anyRequest().authenticated()
+                )
+
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAt(jwtLoginFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 }
-

--- a/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
+++ b/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
@@ -3,11 +3,9 @@ package com.leets.backend.blog.config;
 import com.leets.backend.blog.config.jwt.JwtAuthenticationFilter;
 import com.leets.backend.blog.config.jwt.JwtLoginFilter;
 import com.leets.backend.blog.config.jwt.JwtTokenProvider;
+import com.leets.backend.blog.config.oauth.OAuth2AuthenticationSuccessHandler;
 import com.leets.backend.blog.repository.RefreshTokenRepository;
 import com.leets.backend.blog.service.CustomOAuth2UserService;
-import com.leets.backend.blog.config.oauth.OAuth2AuthenticationSuccessHandler;
-import com.leets.backend.blog.repository.UserRepository;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -15,8 +13,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-// 1. [삭제] WebSecurityCustomizer Import 제거
-// import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,25 +27,23 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final RefreshTokenRepository refreshTokenRepository;
     private final CustomOAuth2UserService customOAuth2UserService;
-    private final UserRepository userRepository;
 
-    private static final String[] SWAGGER_PATHS = {
-            "/v3/api-docs/**",
-            "/swagger-ui/**",
-            "/swagger-ui.html"
-    };
+    // 1. [수정] 직접 생성하지 않고 주입받기 위해 필드 추가
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
 
-    // (생성자는 동일)
+    // UserRepository는 이제 SecurityConfig에서 쓰지 않으므로 제거했습니다.
+
     public SecurityConfig(JwtTokenProvider jwtTokenProvider,
                           AuthenticationConfiguration authenticationConfiguration,
                           RefreshTokenRepository refreshTokenRepository,
                           CustomOAuth2UserService customOAuth2UserService,
-                          UserRepository userRepository) {
+                          // 2. [수정] 생성자 주입
+                          OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.authenticationConfiguration = authenticationConfiguration;
         this.refreshTokenRepository = refreshTokenRepository;
         this.customOAuth2UserService = customOAuth2UserService;
-        this.userRepository = userRepository;
+        this.oAuth2AuthenticationSuccessHandler = oAuth2AuthenticationSuccessHandler;
     }
 
     @Bean
@@ -61,17 +55,6 @@ public class SecurityConfig {
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
     }
-
-    // 2. [삭제] WebSecurityCustomizer Bean 제거
-    /*
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring()
-                .requestMatchers("/favicon.ico")
-                .requestMatchers(SWAGGER_PATHS)
-                .requestMatchers("/error");
-    }
-    */
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -85,8 +68,8 @@ public class SecurityConfig {
         );
         jwtLoginFilter.setFilterProcessesUrl("/login");
 
-        OAuth2AuthenticationSuccessHandler oAuth2SuccessHandler =
-                new OAuth2AuthenticationSuccessHandler(jwtTokenProvider, refreshTokenRepository, userRepository);
+        // 3. [삭제] 여기서 new로 직접 생성하던 코드를 삭제함
+        // OAuth2AuthenticationSuccessHandler oAuth2SuccessHandler = ... (삭제)
 
         http
                 .csrf(csrf -> csrf.disable())
@@ -95,28 +78,19 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService)
                         )
-                        .successHandler(oAuth2SuccessHandler)
+                        // 4. [수정] 주입받은 핸들러 사용
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
                         .failureUrl("/loginFailure")
                 )
-
-                // 3. [수정] authorizeHttpRequests를 한 곳에서 관리
                 .authorizeHttpRequests(authz -> authz
-                        // 3-1. (추가) 기존 WebSecurityCustomizer에 있던 경로들
                         .requestMatchers("/favicon.ico").permitAll()
-                        .requestMatchers(SWAGGER_PATHS).permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/error").permitAll()
-
-                        // 3-2. (기존) OAuth2 및 JWT 관련 경로들
                         .requestMatchers("/auth/**", "/login").permitAll()
                         .requestMatchers("/login/oauth2/code/**").permitAll()
-
-                        // 3-3. (기존) GET 요청 허용 경로
                         .requestMatchers(HttpMethod.GET, "/posts", "/posts/**").permitAll()
-
-                        // 3-4. (기존) 나머지 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 )
-
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAt(jwtLoginFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/leets/backend/blog/config/SwaggerConfig.java
+++ b/src/main/java/com/leets/backend/blog/config/SwaggerConfig.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 
-@OpenAPIDefinition( // 3. 애너테이션 추가
+@OpenAPIDefinition(
         servers = @Server(url = "http://localhost:8080")
 )
 @Configuration

--- a/src/main/java/com/leets/backend/blog/config/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/leets/backend/blog/config/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,92 @@
+package com.leets.backend.blog.config.oauth;
+
+import com.leets.backend.blog.config.jwt.JwtTokenProvider;
+import com.leets.backend.blog.domain.RefreshToken;
+import com.leets.backend.blog.domain.User;
+import com.leets.backend.blog.repository.RefreshTokenRepository;
+import com.leets.backend.blog.repository.UserRepository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Component
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(OAuth2AuthenticationSuccessHandler.class);
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository; // 3. [추가] UserRepository 필드
+
+    // 4. [수정] 생성자에 UserRepository 주입
+    public OAuth2AuthenticationSuccessHandler(JwtTokenProvider jwtTokenProvider,
+                                              RefreshTokenRepository refreshTokenRepository,
+                                              UserRepository userRepository) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+
+        if (kakaoAccount == null) {
+            log.error("Kakao account attributes are missing.");
+            getRedirectStrategy().sendRedirect(request, response, "/loginFailure?error=KakaoAccountMissing");
+            return;
+        }
+
+        String email = (String) kakaoAccount.get("email");
+
+        if (email == null) {
+            log.error("Email not found from OAuth2 provider");
+            getRedirectStrategy().sendRedirect(request, response, "/loginFailure?error=EmailNotFound");
+            return;
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found in DB after OAuth login: " + email));
+
+        Long userId = user.getId();
+        String role = user.getRoleKey();
+
+        log.info("OAuth2 login successful. Issuing JWT for User ID: {}, Email: {}, Role: {}", userId, email, role);
+
+        String accessToken = jwtTokenProvider.createAccessToken(email, role, userId);
+
+        String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        RefreshToken refreshTokenEntity = new RefreshToken(userId, refreshToken);
+        refreshTokenRepository.save(refreshTokenEntity);
+
+        String targetUrl = buildRedirectUrl(accessToken, refreshToken);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    private String buildRedirectUrl(String accessToken, String refreshToken) {
+        String frontendCallbackUrl = "http://localhost:3000/auth/redirect";
+
+        return UriComponentsBuilder.fromUriString(frontendCallbackUrl)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUriString();
+    }
+}

--- a/src/main/java/com/leets/backend/blog/config/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/leets/backend/blog/config/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -1,16 +1,14 @@
 package com.leets.backend.blog.config.oauth;
 
 import com.leets.backend.blog.config.jwt.JwtTokenProvider;
-import com.leets.backend.blog.domain.RefreshToken;
 import com.leets.backend.blog.domain.User;
-import com.leets.backend.blog.repository.RefreshTokenRepository;
-import com.leets.backend.blog.repository.UserRepository;
-
+import com.leets.backend.blog.service.CustomOAuth2UserService;
+import com.leets.backend.blog.service.RefreshTokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -27,16 +25,21 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private static final Logger log = LoggerFactory.getLogger(OAuth2AuthenticationSuccessHandler.class);
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
-    private final UserRepository userRepository; // 3. [추가] UserRepository 필드
+    private final RefreshTokenService refreshTokenService;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
-    // 4. [수정] 생성자에 UserRepository 주입
+    // 1. [추가] 리다이렉트 URI를 담을 필드 선언
+    private final String redirectUri;
+
+    // 2. [수정] 생성자에 @Value를 사용하여 프로퍼티 값 주입
     public OAuth2AuthenticationSuccessHandler(JwtTokenProvider jwtTokenProvider,
-                                              RefreshTokenRepository refreshTokenRepository,
-                                              UserRepository userRepository) {
+                                              RefreshTokenService refreshTokenService,
+                                              CustomOAuth2UserService customOAuth2UserService,
+                                              @Value("${app.oauth2.redirect-uri}") String redirectUri) {
         this.jwtTokenProvider = jwtTokenProvider;
-        this.refreshTokenRepository = refreshTokenRepository;
-        this.userRepository = userRepository;
+        this.refreshTokenService = refreshTokenService;
+        this.customOAuth2UserService = customOAuth2UserService;
+        this.redirectUri = redirectUri;
     }
 
     @Override
@@ -60,8 +63,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             return;
         }
 
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("User not found in DB after OAuth login: " + email));
+        User user = customOAuth2UserService.getUserByEmail(email);
 
         Long userId = user.getId();
         String role = user.getRoleKey();
@@ -69,20 +71,17 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         log.info("OAuth2 login successful. Issuing JWT for User ID: {}, Email: {}, Role: {}", userId, email, role);
 
         String accessToken = jwtTokenProvider.createAccessToken(email, role, userId);
-
         String refreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-        RefreshToken refreshTokenEntity = new RefreshToken(userId, refreshToken);
-        refreshTokenRepository.save(refreshTokenEntity);
+        refreshTokenService.saveRefreshToken(userId, refreshToken);
 
         String targetUrl = buildRedirectUrl(accessToken, refreshToken);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 
     private String buildRedirectUrl(String accessToken, String refreshToken) {
-        String frontendCallbackUrl = "http://localhost:3000/auth/redirect";
-
-        return UriComponentsBuilder.fromUriString(frontendCallbackUrl)
+        // 3. [수정] 하드코딩된 문자열 대신 주입받은 필드(redirectUri) 사용
+        return UriComponentsBuilder.fromUriString(redirectUri)
                 .queryParam("accessToken", accessToken)
                 .queryParam("refreshToken", refreshToken)
                 .build()

--- a/src/main/java/com/leets/backend/blog/config/oauth/OAuthAttributes.java
+++ b/src/main/java/com/leets/backend/blog/config/oauth/OAuthAttributes.java
@@ -1,0 +1,79 @@
+package com.leets.backend.blog.config.oauth;
+import com.leets.backend.blog.domain.User;
+
+import java.util.Map;
+
+// 5. @Getter, @Builder를 사용하지 않는 수동 DTO
+public class OAuthAttributes {
+
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String picture;
+
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email, String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        // 지금은 "kakao"만 처리하지만, 나중에 "google", "naver" 등을 추가할 수 있습니다.
+        if ("kakao".equals(registrationId)) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+
+        // throw new OAuth2AuthenticationException("Unsupported registrationId: " + registrationId);
+        // 또는 기본값 반환
+        return ofKakao(userNameAttributeName, attributes); // 임시로 카카오만 처리
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        // 1. "kakao_account" 맵 추출
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        // 2. "kakao_account" 안의 "profile" 맵 추출
+        Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        String email = (String) kakaoAccount.get("email");
+        String name = (String) kakaoProfile.get("nickname");
+        String picture = (String) kakaoProfile.get("profile_image_url"); // 프로필 이미지 URL
+
+        return new OAuthAttributes(attributes,
+                userNameAttributeName, // "id"
+                name,
+                email,
+                picture);
+    }
+
+    /**
+     * 이 DTO의 정보를 바탕으로 새로운 User 엔티티를 생성합니다.
+     * (회원가입 시 사용)
+     */
+    public User toEntity() {
+        return new User(email, name, picture);
+    }
+
+    // 8. CustomOAuth2UserService에서 사용할 Getter 메서드들
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public String getNameAttributeKey() {
+        return nameAttributeKey;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPicture() {
+        return picture;
+    }
+}

--- a/src/main/java/com/leets/backend/blog/controller/PostController.java
+++ b/src/main/java/com/leets/backend/blog/controller/PostController.java
@@ -23,7 +23,8 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<PostDetailResponse> createPost(@Valid @RequestBody PostSaveRequest request) {
-        PostDetailResponse response = postService.createPost(1L, request); // 임시 userId
+        // userId 파라미터 제거 (Service에서 SecurityUtil로 처리)
+        PostDetailResponse response = postService.createPost(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -35,19 +36,22 @@ public class PostController {
 
     @GetMapping("/{postId}")
     public ResponseEntity<PostDetailResponse> getPostById(@PathVariable Long postId) {
-        PostDetailResponse response = postService.findPostById(1L, postId); // 임시 userId
+        // userId 파라미터 제거
+        PostDetailResponse response = postService.findPostById(postId);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/{postId}")
     public ResponseEntity<PostDetailResponse> updatePost(@PathVariable Long postId, @Valid @RequestBody PostSaveRequest request) {
-        PostDetailResponse response = postService.updatePost(1L, postId, request); // 임시 userId
+        // userId 파라미터 제거
+        PostDetailResponse response = postService.updatePost(postId, request);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(@PathVariable Long postId) {
-        postService.deletePost(1L, postId); // 임시 userId
+        // userId 파라미터 제거
+        postService.deletePost(postId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/leets/backend/blog/domain/Post.java
+++ b/src/main/java/com/leets/backend/blog/domain/Post.java
@@ -1,9 +1,23 @@
 package com.leets.backend.blog.domain;
 
-import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore; // [중요]
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 
 @Entity
 public class Post {
@@ -15,14 +29,16 @@ public class Post {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false, length = 1000)
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id")
     private User user;
 
+    // [중요] Post -> Comment 무한 참조 방지를 위해 @JsonIgnore 추가
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<Comment> comments = new ArrayList<>();
 
     @Column(updatable = false)
@@ -43,6 +59,13 @@ public class Post {
 
     public Post() {}
 
+    public Post(String title, String content, User user) {
+        this.title = title;
+        this.content = content;
+        this.user = user;
+    }
+
+    // --- Getter / Setter ---
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
     public String getTitle() { return title; }

--- a/src/main/java/com/leets/backend/blog/domain/User.java
+++ b/src/main/java/com/leets/backend/blog/domain/User.java
@@ -1,15 +1,15 @@
-package com.leets.backend.blog.domain;
+package com.leets.backend.blog.domain; // 패키지 경로는 기존과 동일하게 유지
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List; // 1. import 추가
+import java.util.List;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails; // 2. import 추가
+import org.springframework.security.core.userdetails.UserDetails;
 
-import jakarta.persistence.CascadeType; // 3. import 추가
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -22,7 +22,7 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "users")
-public class User implements UserDetails { // 4. UserDetails 구현
+public class User implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,7 +32,7 @@ public class User implements UserDetails { // 4. UserDetails 구현
     private String email;
 
     @Column(nullable = false)
-    private String password;
+    private String password; // (OAuth2 사용자는 이 필드를 사용하지 않음)
 
     @Column(nullable = false, unique = true, length = 20)
     private String nickname;
@@ -64,16 +64,32 @@ public class User implements UserDetails { // 4. UserDetails 구현
         updatedAt = LocalDateTime.now();
     }
 
+    // --- 기본 생성자 (JPA용) ---
     public User() {}
+
+    // ========== 1. [OAuth2 추가 부분] OAuth2 신규 가입용 생성자 ==========
+    /**
+     * OAuth2 (Kakao)를 통해 신규 가입하는 사용자를 위한 생성자입니다.
+     * @param email 카카오에서 받은 이메일
+     * @param nickname 카카오에서 받은 닉네임
+     * @param profileImageUrl 카카오에서 받은 프로필 사진 URL
+     */
+    public User(String email, String nickname, String profileImageUrl) {
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        // OAuth2 사용자는 별도 비밀번호가 없으므로, @Column(nullable = false)를 만족시키기 위한
+        // 임시값(혹은 UUID)을 넣어줍니다.
+        this.password = "OAUTH2_USER_PASSWORD_PLACEHOLDER";
+    }
 
     // --- 기존 Getter/Setter (변경 없음) ---
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
-    
-    // UserDetails의 getPassword() 메서드를 만족시킴
-    public String getPassword() { return password; } 
+
+    public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }
     public String getNickname() { return nickname; }
     public void setNickname(String nickname) { this.nickname = nickname; }
@@ -90,40 +106,45 @@ public class User implements UserDetails { // 4. UserDetails 구현
     public List<Comment> getComments() { return comments; }
     public void setComments(List<Comment> comments) { this.comments = comments; }
 
-    
-    // 5. ========== UserDetails 구현 메서드 추가 ==========
 
+    // --- UserDetails 구현 메서드 (기존과 동일) ---
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        // 현재 과제에서는 단순 "ROLE_USER" 권한만 부여합니다.
-        // 추후 Role 엔티티를 만들고 연관관계를 맺어 동적으로 관리할 수 있습니다.
         return List.of(new SimpleGrantedAuthority("ROLE_USER"));
     }
 
     @Override
     public String getUsername() {
-        // Spring Security에서 username은 ID를 의미합니다.
-        // 우리는 email을 ID로 사용하므로 email을 반환합니다.
-        return email;
+        return email; // Spring Security에서 username = email
     }
 
     @Override
-    public boolean isAccountNonExpired() {
-        return true; // 계정 만료 여부 (true: 만료되지 않음)
+    public boolean isAccountNonExpired() { return true; }
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+    @Override
+    public boolean isEnabled() { return true; }
+
+
+    // ========== 2. [OAuth2 추가 부분] 프로필 업데이트 메서드 ==========
+    /**
+     * 카카오에서 받아온 닉네임, 프로필 이미지 URL로 기존 정보를 업데이트합니다.
+     */
+    public User update(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        return this;
     }
 
-    @Override
-    public boolean isAccountNonLocked() {
-        return true; // 계정 잠김 여부 (true: 잠기지 않음)
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true; // 비밀번호 만료 여부 (true: 만료되지 않음)
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true; // 계정 활성화 여부 (true: 활성화됨)
+    // ========== 3. [OAuth2 추가 부분] 권한(Role) 반환 메서드 ==========
+    /**
+     * CustomOAuth2UserService에서 사용자의 권한을 참조할 때 사용합니다.
+     * getAuthorities()와 일치하도록 "ROLE_USER"를 반환합니다.
+     */
+    public String getRoleKey() {
+        // 현재 UserDetails 구현에서 "ROLE_USER"로 고정되어 있으므로, 동일한 값을 반환
+        return "ROLE_USER";
     }
 }

--- a/src/main/java/com/leets/backend/blog/domain/User.java
+++ b/src/main/java/com/leets/backend/blog/domain/User.java
@@ -1,9 +1,11 @@
-package com.leets.backend.blog.domain; // 패키지 경로는 기존과 동일하게 유지
+package com.leets.backend.blog.domain;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore; // [중요]
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -21,7 +23,7 @@ import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "users")
+@Table(name = "users") // MySQL 예약어 충돌 방지
 public class User implements UserDetails {
 
     @Id
@@ -32,7 +34,7 @@ public class User implements UserDetails {
     private String email;
 
     @Column(nullable = false)
-    private String password; // (OAuth2 사용자는 이 필드를 사용하지 않음)
+    private String password;
 
     @Column(nullable = false, unique = true, length = 20)
     private String nickname;
@@ -47,10 +49,14 @@ public class User implements UserDetails {
 
     private LocalDateTime updatedAt;
 
+    // [중요] User -> Post 무한 참조 방지를 위해 @JsonIgnore 추가
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<Post> posts = new ArrayList<>();
 
+    // [중요] User -> Comment 무한 참조 방지를 위해 @JsonIgnore 추가
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<Comment> comments = new ArrayList<>();
 
     @PrePersist
@@ -64,31 +70,20 @@ public class User implements UserDetails {
         updatedAt = LocalDateTime.now();
     }
 
-    // --- 기본 생성자 (JPA용) ---
     public User() {}
 
-    // ========== 1. [OAuth2 추가 부분] OAuth2 신규 가입용 생성자 ==========
-    /**
-     * OAuth2 (Kakao)를 통해 신규 가입하는 사용자를 위한 생성자입니다.
-     * @param email 카카오에서 받은 이메일
-     * @param nickname 카카오에서 받은 닉네임
-     * @param profileImageUrl 카카오에서 받은 프로필 사진 URL
-     */
     public User(String email, String nickname, String profileImageUrl) {
         this.email = email;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
-        // OAuth2 사용자는 별도 비밀번호가 없으므로, @Column(nullable = false)를 만족시키기 위한
-        // 임시값(혹은 UUID)을 넣어줍니다.
         this.password = "OAUTH2_USER_PASSWORD_PLACEHOLDER";
     }
 
-    // --- 기존 Getter/Setter (변경 없음) ---
+    // --- Getter / Setter ---
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
-
     public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }
     public String getNickname() { return nickname; }
@@ -106,18 +101,13 @@ public class User implements UserDetails {
     public List<Comment> getComments() { return comments; }
     public void setComments(List<Comment> comments) { this.comments = comments; }
 
-
-    // --- UserDetails 구현 메서드 (기존과 동일) ---
+    // --- UserDetails 구현 ---
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_USER"));
     }
-
     @Override
-    public String getUsername() {
-        return email; // Spring Security에서 username = email
-    }
-
+    public String getUsername() { return email; }
     @Override
     public boolean isAccountNonExpired() { return true; }
     @Override
@@ -127,24 +117,10 @@ public class User implements UserDetails {
     @Override
     public boolean isEnabled() { return true; }
 
-
-    // ========== 2. [OAuth2 추가 부분] 프로필 업데이트 메서드 ==========
-    /**
-     * 카카오에서 받아온 닉네임, 프로필 이미지 URL로 기존 정보를 업데이트합니다.
-     */
     public User update(String nickname, String profileImageUrl) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
         return this;
     }
-
-    // ========== 3. [OAuth2 추가 부분] 권한(Role) 반환 메서드 ==========
-    /**
-     * CustomOAuth2UserService에서 사용자의 권한을 참조할 때 사용합니다.
-     * getAuthorities()와 일치하도록 "ROLE_USER"를 반환합니다.
-     */
-    public String getRoleKey() {
-        // 현재 UserDetails 구현에서 "ROLE_USER"로 고정되어 있으므로, 동일한 값을 반환
-        return "ROLE_USER";
-    }
+    public String getRoleKey() { return "ROLE_USER"; }
 }

--- a/src/main/java/com/leets/backend/blog/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/leets/backend/blog/service/CustomOAuth2UserService.java
@@ -1,0 +1,92 @@
+package com.leets.backend.blog.service;
+
+// 1. 필요한 Import
+import com.leets.backend.blog.domain.User;
+import com.leets.backend.blog.repository.UserRepository;
+import com.leets.backend.blog.config.oauth.OAuthAttributes;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    // 2. Logger 수동 초기화 (@Slf4j 대신 사용)
+    private static final Logger log = LoggerFactory.getLogger(CustomOAuth2UserService.class);
+
+    // 3. final 필드
+    private final UserRepository userRepository;
+
+    // 4. @RequiredArgsConstructor 대신 수동 생성자 주입
+    public CustomOAuth2UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        // 1. 기본 OAuth2UserService 객체를 사용하여 사용자 정보 가져오기
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        // 2. 현재 로그인 진행 중인 서비스(kakao)를 구분
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        // 3. OAuth2 로그인 시 키가 되는 필드 값 (카카오는 "id"를 사용)
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint()
+                .getUserNameAttributeName();
+
+        // 4. OAuthAttributes: 가져온 사용자 정보(Map)를 분석하여 DTO로 변환
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        log.info("[OAuth2User Attributes] : {}", attributes);
+
+        // 5. 카카오 응답 파싱 (OAuthAttributes 클래스가 담당)
+        OAuthAttributes oAuthAttributes = OAuthAttributes.of(registrationId, userNameAttributeName, attributes);
+
+        // 6. 사용자 저장 또는 업데이트 (DB 처리)
+        User user = saveOrUpdate(oAuthAttributes);
+
+        // 7. Spring Security가 인증을 위해 사용하는 객체 반환
+        return new DefaultOAuth2User(
+                // 권한 부여 (예: ROLE_USER)
+                Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())),
+                oAuthAttributes.getAttributes(),
+                oAuthAttributes.getNameAttributeKey());
+    }
+
+    /**
+     * DB에 사용자 정보를 저장하거나, 이미 있다면 정보를 업데이트합니다.
+     */
+    private User saveOrUpdate(OAuthAttributes attributes) {
+
+        // 이메일로 기존 사용자 찾기
+        User user = userRepository.findByEmail(attributes.getEmail())
+                // 2. 기존 사용자가 있다면, 이름과 프로필 사진만 업데이트
+                .map(entity -> {
+                    log.info("Existing user found. Updating info... (Email: {})", attributes.getEmail());
+                    return entity.update(attributes.getName(), attributes.getPicture());
+                })
+                // 3. 기존 사용자가 없다면, 새로운 User 엔티티 생성 (회원가입)
+                .orElseGet(() -> {
+                    log.info("New user. Registering... (Email: {})", attributes.getEmail());
+                    return attributes.toEntity();
+                });
+
+        return userRepository.save(user); // DB에 저장
+    }
+}

--- a/src/main/java/com/leets/backend/blog/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/leets/backend/blog/service/CustomOAuth2UserService.java
@@ -1,13 +1,10 @@
 package com.leets.backend.blog.service;
 
-// 1. 필요한 Import
+import com.leets.backend.blog.config.oauth.OAuthAttributes;
 import com.leets.backend.blog.domain.User;
 import com.leets.backend.blog.repository.UserRepository;
-import com.leets.backend.blog.config.oauth.OAuthAttributes;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -24,13 +21,10 @@ import java.util.Map;
 @Service
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
-    // 2. Logger 수동 초기화 (@Slf4j 대신 사용)
     private static final Logger log = LoggerFactory.getLogger(CustomOAuth2UserService.class);
 
-    // 3. final 필드
     private final UserRepository userRepository;
 
-    // 4. @RequiredArgsConstructor 대신 수동 생성자 주입
     public CustomOAuth2UserService(UserRepository userRepository) {
         this.userRepository = userRepository;
     }
@@ -38,55 +32,48 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     @Override
     @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-
-        // 1. 기본 OAuth2UserService 객체를 사용하여 사용자 정보 가져오기
         OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
         OAuth2User oAuth2User = delegate.loadUser(userRequest);
 
-        // 2. 현재 로그인 진행 중인 서비스(kakao)를 구분
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-
-        // 3. OAuth2 로그인 시 키가 되는 필드 값 (카카오는 "id"를 사용)
         String userNameAttributeName = userRequest.getClientRegistration()
                 .getProviderDetails().getUserInfoEndpoint()
                 .getUserNameAttributeName();
 
-        // 4. OAuthAttributes: 가져온 사용자 정보(Map)를 분석하여 DTO로 변환
         Map<String, Object> attributes = oAuth2User.getAttributes();
         log.info("[OAuth2User Attributes] : {}", attributes);
 
-        // 5. 카카오 응답 파싱 (OAuthAttributes 클래스가 담당)
         OAuthAttributes oAuthAttributes = OAuthAttributes.of(registrationId, userNameAttributeName, attributes);
 
-        // 6. 사용자 저장 또는 업데이트 (DB 처리)
         User user = saveOrUpdate(oAuthAttributes);
 
-        // 7. Spring Security가 인증을 위해 사용하는 객체 반환
         return new DefaultOAuth2User(
-                // 권한 부여 (예: ROLE_USER)
                 Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())),
                 oAuthAttributes.getAttributes(),
                 oAuthAttributes.getNameAttributeKey());
     }
 
-    /**
-     * DB에 사용자 정보를 저장하거나, 이미 있다면 정보를 업데이트합니다.
-     */
     private User saveOrUpdate(OAuthAttributes attributes) {
-
-        // 이메일로 기존 사용자 찾기
         User user = userRepository.findByEmail(attributes.getEmail())
-                // 2. 기존 사용자가 있다면, 이름과 프로필 사진만 업데이트
                 .map(entity -> {
                     log.info("Existing user found. Updating info... (Email: {})", attributes.getEmail());
                     return entity.update(attributes.getName(), attributes.getPicture());
                 })
-                // 3. 기존 사용자가 없다면, 새로운 User 엔티티 생성 (회원가입)
                 .orElseGet(() -> {
                     log.info("New user. Registering... (Email: {})", attributes.getEmail());
                     return attributes.toEntity();
                 });
 
-        return userRepository.save(user); // DB에 저장
+        return userRepository.save(user);
+    }
+
+    /**
+     * [추가] 핸들러에서 유저 정보를 조회할 때 사용
+     * Repository 접근 로직을 Service 계층으로 캡슐화
+     */
+    @Transactional(readOnly = true)
+    public User getUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found in DB after OAuth login: " + email));
     }
 }

--- a/src/main/java/com/leets/backend/blog/service/PostService.java
+++ b/src/main/java/com/leets/backend/blog/service/PostService.java
@@ -5,13 +5,16 @@ import com.leets.backend.blog.domain.User;
 import com.leets.backend.blog.dto.PostDetailResponse;
 import com.leets.backend.blog.dto.PostListResponse;
 import com.leets.backend.blog.dto.PostSaveRequest;
+import com.leets.backend.blog.exception.PostNotFoundException;
+import com.leets.backend.blog.exception.UserNotFoundException;
 import com.leets.backend.blog.repository.PostRepository;
 import com.leets.backend.blog.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.leets.backend.blog.util.SecurityUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -25,11 +28,15 @@ public class PostService {
         this.userRepository = userRepository;
     }
 
-    //게시물 생성
+    // 게시물 생성
     @Transactional
-    public PostDetailResponse createPost(Long userId, PostSaveRequest request) {
-        User writer = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다. id=" + userId));
+    public PostDetailResponse createPost(PostSaveRequest request) {
+        // 1. 로그인한 사용자 ID 가져오기 (로그인 안되어있으면 예외 발생)
+        Long currentUserId = SecurityUtil.getCurrentUserId()
+                .orElseThrow(() -> new SecurityException("로그인이 필요한 서비스입니다."));
+
+        User writer = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new UserNotFoundException(currentUserId));
 
         Post newPost = new Post();
         newPost.setTitle(request.getTitle());
@@ -38,10 +45,10 @@ public class PostService {
 
         Post savedPost = postRepository.save(newPost);
 
-        return new PostDetailResponse(savedPost, true);
+        return new PostDetailResponse(savedPost, true); // 작성자 본인이므로 true
     }
-    
-    // 모든 게시물 목록조회
+
+    // 모든 게시물 목록 조회
     @Transactional(readOnly = true)
     public List<PostListResponse> findAllPosts() {
         return postRepository.findAll().stream()
@@ -49,24 +56,34 @@ public class PostService {
                 .collect(Collectors.toList());
     }
 
-    //특정 게시물
+    // 특정 게시물 조회
     @Transactional(readOnly = true)
-    public PostDetailResponse findPostById(Long userId, Long postId) {
+    public PostDetailResponse findPostById(Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시물을 찾을 수 없습니다. id=" + postId));
+                .orElseThrow(() -> new PostNotFoundException(postId));
 
-        boolean isOwner = post.getUser().getId().equals(userId);
+        // 2. 현재 로그인한 사용자 확인 (비로그인 상태일 수도 있음)
+        Optional<Long> currentUserId = SecurityUtil.getCurrentUserId();
+
+        // 3. 소유권 확인 (로그인 상태이며, 작성자 ID와 일치하면 true)
+        boolean isOwner = currentUserId.isPresent() &&
+                post.getUser().getId().equals(currentUserId.get());
 
         return new PostDetailResponse(post, isOwner);
     }
 
-    //수정
+    // 수정
     @Transactional
-    public PostDetailResponse updatePost(Long userId, Long postId, PostSaveRequest request) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시물을 찾을 수 없습니다. id=" + postId));
+    public PostDetailResponse updatePost(Long postId, PostSaveRequest request) {
+        // 1. 로그인 확인
+        Long currentUserId = SecurityUtil.getCurrentUserId()
+                .orElseThrow(() -> new SecurityException("로그인이 필요한 서비스입니다."));
 
-        if (!post.getUser().getId().equals(userId)) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        // 2. 소유권 검증 (작성자와 현재 로그인한 유저가 다르면 예외)
+        if (!post.getUser().getId().equals(currentUserId)) {
             throw new SecurityException("게시물을 수정할 권한이 없습니다.");
         }
 
@@ -76,13 +93,18 @@ public class PostService {
         return new PostDetailResponse(post, true);
     }
 
-    //삭제
+    // 삭제
     @Transactional
-    public void deletePost(Long userId, Long postId) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 게시물을 찾을 수 없습니다. id=" + postId));
+    public void deletePost(Long postId) {
+        // 1. 로그인 확인
+        Long currentUserId = SecurityUtil.getCurrentUserId()
+                .orElseThrow(() -> new SecurityException("로그인이 필요한 서비스입니다."));
 
-        if (!post.getUser().getId().equals(userId)) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        // 2. 소유권 검증
+        if (!post.getUser().getId().equals(currentUserId)) {
             throw new SecurityException("게시물을 삭제할 권한이 없습니다.");
         }
 

--- a/src/main/java/com/leets/backend/blog/service/RefreshTokenService.java
+++ b/src/main/java/com/leets/backend/blog/service/RefreshTokenService.java
@@ -1,0 +1,22 @@
+package com.leets.backend.blog.service;
+
+import com.leets.backend.blog.domain.RefreshToken;
+import com.leets.backend.blog.repository.RefreshTokenRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshTokenService(RefreshTokenRepository refreshTokenRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    @Transactional
+    public void saveRefreshToken(Long userId, String newRefreshToken) {
+        RefreshToken refreshToken = new RefreshToken(userId, newRefreshToken);
+        refreshTokenRepository.save(refreshToken);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,12 +10,12 @@ spring:
   # JPA 설정
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true
     show-sql: true
-    open-in-view: false
+    open-in-view: true
 
   # Spring Security (OAuth2 Client) 설정
   security:
@@ -55,3 +55,9 @@ jwt:
   secret: "eW91ci1zdXBlci1zdHJvbmctc2VjcmV0LWtleS1iYXNlNjQtZW5jb2RlZA=="
   access-token-expiration-ms: 1800000
   refresh-token-expiration-ms: 604800000
+
+# [추가] 프론트엔드 리다이렉트 URL 설정
+# OAuth2AuthenticationSuccessHandler에서 @Value로 사용됨
+app:
+  oauth2:
+    redirect-uri: http://localhost:3000/auth/redirect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,10 +2,12 @@ server:
   port: 8080
 
 spring:
+  # 데이터베이스 설정
   datasource:
     url: jdbc:mysql://localhost:3306/blog?serverTimezone=Asia/Seoul
     username: root
     password: 1234
+  # JPA 설정
   jpa:
     hibernate:
       ddl-auto: update
@@ -15,6 +17,31 @@ spring:
     show-sql: true
     open-in-view: false
 
+  # Spring Security (OAuth2 Client) 설정
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: 385723754660a385ed7ea250b98795e1 # REST API 키
+            client-authentication-method: post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+
+            scope:
+              - profile_nickname
+              - profile_image
+
+            client-name: Kakao
+
+        provider:
+          # 카카오 Oauth2 Provider 설정
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id # 카카오 사용자 식별자 필드
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
@@ -23,18 +50,8 @@ springdoc:
     version: "v1.0.0"
     description: "블로그 프로젝트 API 명세서입니다."
 
-# ==================================
 # JWT (JSON Web Token) 설정
-# ==================================
 jwt:
-  # HMAC-SHA 알고리즘을 위한 비밀키. Base64로 인코딩된 64바이트 이상의 문자열 권장
-  # 예시: (테스트용)
   secret: "eW91ci1zdXBlci1zdHJvbmctc2VjcmV0LWtleS1iYXNlNjQtZW5jb2RlZA=="
-
-  # Access Token 만료 시간 (밀리초 단위)
-  # 30분 = 30 * 60 * 1000 = 1800000
   access-token-expiration-ms: 1800000
-
-  # Refresh Token 만료 시간 (밀리초 단위)
-  # 7일 = 7 * 24 * 60 * 60 * 1000 = 604800000
   refresh-token-expiration-ms: 604800000


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

기존의 JWT 기반 로컬 로그인 방식에 , 사용자의 편의성을 높이기 위해 카카오 소셜 로그인(OAuth 2.0) 기능을 구현

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

STATELESS vs STATEFUL 충돌: 기존 JWT 인증은 STATELESS (무상태)로 운영 중이었으나, Spring Security OAuth2의 기본 구현은 HttpSession (상태 유지)에 의존

JWT 미발급 문제: OAuth2 로그인 성공 시, 단순히 리디렉션만 해서는 STATELESS 환경의 클라이언트가 JWT를 발급받지 못하는 문제를 발견

카카오 설정 오류: 카카오 개발자 센터의 설정 오류로 인해 다양한 KOE 에러(KOE004, KOE205) 및 401, 400 에러를 만났습니다. (Redirect URI 불일치, 앱 비활성화, 동의 항목 미설정, Client Secret 설정 불일치 등)

토큰 생성 파라미터 불일치: JwtTokenProvider가 email이 아닌 Long id를 요구하는 등, 기존 JWT 시스템과 OAuth 응답 간의 데이터 매핑 조정이 필요

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<img width="781" height="1221" alt="image" src="https://github.com/user-attachments/assets/83250699-6fc8-4ced-9185-406835f4ac12" />



<br>

## 4. 완료 사항

1.의존성 추가: build.gradle에 spring-boot-starter-oauth2-client 의존성을 추가
2.application.yml 설정: 카카오 REST API 키, Redirect URI, Provider 엔드포인트 및 scope를 설정
3.SecurityConfig 수정 : STATELESS 정책을 유지하기 위해, 기본 리디렉션 대신 커스텀 핸들러를 사용하도록 설정, 존 JWT 필터 체인을 유지하면서 .oauth2Login() 설정을 추가
4.CustomOAuth2UserService 구현 : DB에서 사용자를 조회(findByEmail)하고, 신규 사용자는 저장(회원가입), 기존 사용자는 정보를 업데이트(update)하도록 구현, OAuthAttributes DTO를 통해 응답 데이터를 정규화
5. User 엔티티 수정: OAuth2 신규 가입자를 위한 생성자 및 프로필 업데이트용 update() 메서드를 추가
6.  OAuth2 인증 성공 직후 호출되어, STATELESS 환경에 맞게 JWT(Access/Refresh Token)를 직접 발급, 발급된 토큰을 프론트엔드 URL(http://localhost:3000/auth/redirect)의 쿼리 파라미터로 전달하여 리디렉션


<br>

## 5. 추가 사항

closed #111 

<br>