### PR TITLE
[6주차]강태이/[feat]카카오 회원가입 및 로그인 기능 구현

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework.boot/spring-boot-configuration-processor/3.3.5/33b9d3f722281e8f9dbbd284135ee8b9909c42cf/spring-boot-configuration-processor-3.3.5.jar" />
+        </processorPath>
+        <module name="blog_manage.main" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/6th-BE-Blog.iml" filepath="$PROJECT_DIR$/.idea/6th-BE-Blog.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/blog_manage.main.iml" filepath="$PROJECT_DIR$/.idea/modules/blog_manage.main.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules/blog_manage.main.iml
+++ b/.idea/modules/blog_manage.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../blog_manage/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../blog_manage/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/blog_manage/build.gradle
+++ b/blog_manage/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.7'
-    id 'org.cyclonedx.bom' version '2.3.0'
 }
 
 group = 'com.leets.backend'
@@ -20,20 +19,31 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    // Spring Boot 기본
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-
-    runtimeOnly 'com.h2database:h2'
-
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly 'mysql:mysql-connector-java:8.0.33'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    // DB
+    runtimeOnly 'com.h2database:h2'                  // 테스트용
+    runtimeOnly 'mysql:mysql-connector-java:8.0.33'  // 실제 배포용
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+    // OpenAPI (Swagger UI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    // 설정 메타데이터
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
+    // 테스트
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/blog_manage/build.gradle
+++ b/blog_manage/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.6'
-    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.springframework.boot' version '3.3.5'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.leets.backend'
@@ -36,7 +36,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
     // OpenAPI (Swagger UI)
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
     // 설정 메타데이터
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/blog_manage/src/main/java/com/leets/backend/blog/common/ApiResponse.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/common/ApiResponse.java
@@ -28,16 +28,17 @@ public class ApiResponse<T> {
         return response;
     }
 
-    // Getter 추가 (JSON 직렬화용)
-    public int getStatus() {
-        return status;
+    // 데이터가 없을 때 간단하게 사용
+    public static <T> ApiResponse<T> onSuccess(String message) {
+        return onSuccess(HttpStatus.OK, message, null);
     }
 
-    public String getMessage() {
-        return message;
+    public static <T> ApiResponse<T> onFailure(HttpStatus status, String message) {
+        return onFailure(status, message, null);
     }
 
-    public T getData() {
-        return data;
-    }
+    // Getter
+    public int getStatus() { return status; }
+    public String getMessage() { return message; }
+    public T getData() { return data; }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/config/JwtAuthenticationFilter.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/config/JwtAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package com.leets.backend.blog.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+import com.leets.backend.blog.service.CustomUserDetailsService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, CustomUserDetailsService userDetailsService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+            throws ServletException, IOException {
+        String header = req.getHeader("Authorization");
+        String token = null;
+        if (header != null && header.startsWith("Bearer ")) {
+            token = header.substring(7);
+        }
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            String email = jwtTokenProvider.getSubject(token);
+            var userDetails = userDetailsService.loadUserByUsername(email);
+            var auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+        chain.doFilter(req, res);
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/config/JwtEntryPoint.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/config/JwtEntryPoint.java
@@ -2,15 +2,22 @@ package com.leets.backend.blog.config;
 
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
 import jakarta.servlet.http.*;
 import java.io.IOException;
 
+@Component
 public class JwtEntryPoint implements AuthenticationEntryPoint {
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setContentType("application/json");
-        response.getWriter().write("{\"message\":\"Unauthorized\"}");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.setContentType("application/json; charset=UTF-8");
+
+        // 인증 실패 메세지
+        String json = ("{\"message\":\"Unauthorized - 인증이 필요합니다.\"}");
+
+        response.getWriter().write(json);
     }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/config/JwtEntryPoint.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/config/JwtEntryPoint.java
@@ -1,0 +1,16 @@
+package com.leets.backend.blog.config;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import jakarta.servlet.http.*;
+import java.io.IOException;
+
+public class JwtEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"message\":\"Unauthorized\"}");
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/config/JwtTokenProvider.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/config/JwtTokenProvider.java
@@ -18,9 +18,10 @@ public class JwtTokenProvider {
     private final long refreshTokenValidityMs;
 
     public JwtTokenProvider(
-            @Value("${jwt.secret}") String secret,
-            @Value("${jwt.access-token-validity}") long accessValidity,
-            @Value("${jwt.refresh-token-validity}") long refreshValidity) {
+            @Value("${spring.jwt.secret}") String secret,
+            @Value("${spring.jwt.access-token-validity}") long accessValidity,
+            @Value("${spring.jwt.refresh-token-validity}") long refreshValidity) {
+
         this.key = Keys.hmacShaKeyFor(secret.getBytes());
         this.accessTokenValidityMs = accessValidity;
         this.refreshTokenValidityMs = refreshValidity;
@@ -52,11 +53,9 @@ public class JwtTokenProvider {
     }
 
     public String generateToken(String subject) {
-        // 기본적으로 USER 권한으로 AccessToken 생성
         return createAccessToken(subject, "ROLE_USER");
     }
 
-    // 토큰 유효성 검사
     public boolean validateToken(String token) {
         try {
             Jwts.parser().setSigningKey(key).build().parseClaimsJws(token);
@@ -66,7 +65,6 @@ public class JwtTokenProvider {
         }
     }
 
-    // 토큰에서 이메일 추출
     public String getSubject(String token) {
         return Jwts.parser().setSigningKey(key)
                 .build()
@@ -75,7 +73,6 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
-    // 토큰 만료시간 추출
     public Date getExpiration(String token) {
         return Jwts.parser().setSigningKey(key)
                 .build()

--- a/blog_manage/src/main/java/com/leets/backend/blog/config/JwtTokenProvider.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/config/JwtTokenProvider.java
@@ -1,0 +1,69 @@
+package com.leets.backend.blog.config;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+    private final long accessTokenValidityMs;
+    private final long refreshTokenValidityMs;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-validity}") long accessValidity,
+            @Value("${jwt.refresh-token-validity}") long refreshValidity) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+        this.accessTokenValidityMs = accessValidity;
+        this.refreshTokenValidityMs = refreshValidity;
+    }
+
+    public String createAccessToken(String subject, String role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenValidityMs);
+        return Jwts.builder()
+                .setSubject(subject)
+                .claim("role", role)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(String subject) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenValidityMs);
+        return Jwts.builder()
+                .setSubject(subject)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    public String getSubject(String token) {
+        return Jwts.parser().setSigningKey(key).
+                build().parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public Date getExpiration(String token) {
+        return Jwts.parser().setSigningKey(key).build().parseClaimsJws(token).getBody().getExpiration();
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/config/JwtTokenProvider.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/config/JwtTokenProvider.java
@@ -29,6 +29,7 @@ public class JwtTokenProvider {
     public String createAccessToken(String subject, String role) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + accessTokenValidityMs);
+
         return Jwts.builder()
                 .setSubject(subject)
                 .claim("role", role)
@@ -41,6 +42,7 @@ public class JwtTokenProvider {
     public String createRefreshToken(String subject) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + refreshTokenValidityMs);
+
         return Jwts.builder()
                 .setSubject(subject)
                 .setIssuedAt(now)
@@ -49,6 +51,12 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    public String generateToken(String subject) {
+        // 기본적으로 USER 권한으로 AccessToken 생성
+        return createAccessToken(subject, "ROLE_USER");
+    }
+
+    // 토큰 유효성 검사
     public boolean validateToken(String token) {
         try {
             Jwts.parser().setSigningKey(key).build().parseClaimsJws(token);
@@ -58,12 +66,21 @@ public class JwtTokenProvider {
         }
     }
 
+    // 토큰에서 이메일 추출
     public String getSubject(String token) {
-        return Jwts.parser().setSigningKey(key).
-                build().parseClaimsJws(token).getBody().getSubject();
+        return Jwts.parser().setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
     }
 
+    // 토큰 만료시간 추출
     public Date getExpiration(String token) {
-        return Jwts.parser().setSigningKey(key).build().parseClaimsJws(token).getBody().getExpiration();
+        return Jwts.parser().setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
     }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/config/OpenApiConfig.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/config/OpenApiConfig.java
@@ -1,0 +1,40 @@
+package com.leets.backend.blog.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        // Security Scheme 이름 정의
+        String securitySchemeName = "Bearer Authentication";
+
+        // 모든 API에 이 Security Requirement를 적용
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList(securitySchemeName);
+
+        // JWT Bearer Token을 위한 Security Scheme 정의
+        SecurityScheme securityScheme = new SecurityScheme()
+                .name(securitySchemeName)
+                .type(SecurityScheme.Type.HTTP)      // HTTP 인증 방식
+                .scheme("bearer")                     // Bearer 토큰 사용
+                .bearerFormat("JWT")                  // JWT 형식
+                .description("JWT 토큰을 입력하세요. 'Bearer ' 접두사는 자동으로 추가됩니다.");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Blog Management API")
+                        .description("블로그 관리 시스템 API 문서")
+                        .version("1.0.0"))
+                .addSecurityItem(securityRequirement)  // 모든 API에 보안 적용
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, securityScheme));
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.leets.backend.blog.config;
 
+import com.leets.backend.blog.service.CustomUserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -11,13 +12,23 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
 
-    // 비밀번호 인코더 빈
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService userDetailsService;
+
+    // 생성자를 통한 의존성 주입
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider, CustomUserDetailsService userDetailsService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    // 비밀번호 인코더 Bean 등록
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -29,16 +40,34 @@ public class SecurityConfig {
         return authenticationConfiguration.getAuthenticationManager();
     }
 
-    // 보안 필터 체인
+    // JWT 인증 필터 Bean 등록
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService);
+    }
+
+    // 보안 필터 체인 설정
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                // CSRF 비활성화
                 .csrf(csrf -> csrf.disable())
+
+                // 요청별 인가 규칙 설정
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                        .anyRequest().authenticated()
+                        .requestMatchers(
+                                "/api/auth/**", // 인증 관련 경로 허용
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
+                        .anyRequest().authenticated() // 나머지는 인증 필요
                 )
+
+                // 세션 사용 안 함 (STATELESS)
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/blog_manage/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
@@ -21,13 +21,18 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService userDetailsService;
+    private final JwtEntryPoint jwtEntryPoint;
 
     // 생성자를 통한 의존성 주입
-    public SecurityConfig(JwtTokenProvider jwtTokenProvider, CustomUserDetailsService userDetailsService) {
+    public SecurityConfig(
+            JwtTokenProvider jwtTokenProvider,
+            CustomUserDetailsService userDetailsService,
+            JwtEntryPoint jwtEntryPoint
+    ) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.userDetailsService = userDetailsService;
+        this.jwtEntryPoint = jwtEntryPoint;
     }
-
     // 비밀번호 인코더 Bean 등록
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -50,22 +55,27 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // CSRF 비활성화
                 .csrf(csrf -> csrf.disable())
 
-                // 요청별 인가 규칙 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/auth/**", // 인증 관련 경로 허용
+                                "/api/auth/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html"
                         ).permitAll()
-                        .anyRequest().authenticated() // 나머지는 인증 필요
+                        .requestMatchers("/api/auth/kakao/callback").permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
                 )
 
-                // 세션 사용 안 함 (STATELESS)
-                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                .sessionManagement(sess ->
+                        sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+
+                .exceptionHandling(ex ->
+                        ex.authenticationEntryPoint(jwtEntryPoint)
+                );
 
         http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 

--- a/blog_manage/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
@@ -2,69 +2,44 @@ package com.leets.backend.blog.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
+    // 비밀번호 인코더 빈
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                // 세션 비활성화
-                .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-                .csrf(csrf -> csrf.disable()) // API용 CSRF 비활성화
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-
-                // 폼 로그인, http 인증 비활성화
-                .formLogin(form -> form.disable())
-                .httpBasic(basic -> basic.disable())
-
-                // 요청에 대한 인가 설정
-                .authorizeHttpRequests(authorize -> authorize
-                        // Swagger UI 경로 허용
-                        .requestMatchers(
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/swagger-resources/**",
-                                "/webjars/**"
-                        ).permitAll()
-
-                        // API 테스트용 경로 허용
-                        .requestMatchers(
-                                "/api/**",
-                                "/posts/**",
-                                "/"
-                        ).permitAll()
-
-                        // 나머지는 인증 필요
-                        .anyRequest().authenticated()
-                );
-
-        return http.build();
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
+    // AuthenticationManager Bean 등록
     @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of("*")); // Swagger, Postman 모두 허용
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("*"));
-        configuration.setAllowCredentials(true);
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
+    // 보안 필터 체인
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
     }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/config/SecurityConfig.java
@@ -6,6 +6,11 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -18,32 +23,48 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-                .csrf(csrf -> csrf.disable()) // CSRF 보호 비활성화 (API 서버에서는 보통 비활성화)
-                .cors(cors -> cors.disable())
+                .csrf(csrf -> csrf.disable()) // API용 CSRF 비활성화
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 
                 // 폼 로그인, http 인증 비활성화
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
 
-                // 요청에 대한 인가(Authorization) 설정
+                // 요청에 대한 인가 설정
                 .authorizeHttpRequests(authorize -> authorize
-                        // Swagger UI 및 API 문서 경로에 대한 접근 허용
+                        // Swagger UI 경로 허용
                         .requestMatchers(
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/swagger-resources/**",
-                                "/webjars/**",
-                                "/api/**"
+                                "/webjars/**"
                         ).permitAll()
+
+                        // API 테스트용 경로 허용
                         .requestMatchers(
+                                "/api/**",
                                 "/posts/**",
                                 "/"
                         ).permitAll()
-                        // 그 외 모든 요청은 인가 필요
+
+                        // 나머지는 인증 필요
                         .anyRequest().authenticated()
                 );
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*")); // Swagger, Postman 모두 허용
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/controller/AuthController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/controller/AuthController.java
@@ -20,6 +20,7 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@RequestBody SignUpRequest req) {
         authService.signup(req);
+
         return ResponseEntity.ok(ApiResponse.onSuccess("User registered"));
     }
 

--- a/blog_manage/src/main/java/com/leets/backend/blog/controller/AuthController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/controller/AuthController.java
@@ -3,36 +3,44 @@ package com.leets.backend.blog.controller;
 import com.leets.backend.blog.dto.auth.*;
 import com.leets.backend.blog.common.ApiResponse;
 import com.leets.backend.blog.service.AuthService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
+
     private final AuthService authService;
-    public AuthController(AuthService authService) { this.authService = authService; }
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
 
+    // 회원가입
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(@RequestBody SignUpRequest req) {
+    public ResponseEntity<ApiResponse<Void>> signup(@RequestBody SignUpRequest req) {
         authService.signup(req);
-        return ResponseEntity.ok(new ApiResponse(true, "User registered"));
+        return ResponseEntity.ok(ApiResponse.onSuccess("User registered"));
     }
 
+    // 로그인
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest req) {
+    public ResponseEntity<ApiResponse<TokenResponse>> login(@RequestBody LoginRequest req) {
         TokenResponse tokens = authService.login(req);
-        return ResponseEntity.ok(tokens);
+        return ResponseEntity.ok(ApiResponse.onSuccess(HttpStatus.OK, "Login success", tokens));
     }
 
+    // 토큰 재발급
     @PostMapping("/refresh")
-    public ResponseEntity<TokenResponse> refresh(@RequestBody RefreshTokenRequest rreq) {
+    public ResponseEntity<ApiResponse<TokenResponse>> refresh(@RequestBody RefreshTokenRequest rreq) {
         TokenResponse tokens = authService.refreshToken(rreq.getRefreshToken());
-        return ResponseEntity.ok(tokens);
+        return ResponseEntity.ok(ApiResponse.onSuccess(HttpStatus.OK, "Token refreshed", tokens));
     }
 
+    // 로그아웃
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(@RequestParam String email) {
+    public ResponseEntity<ApiResponse<Void>> logout(@RequestParam String email) {
         authService.logout(email);
-        return ResponseEntity.ok(new ApiResponse(true, "Logged out"));
+        return ResponseEntity.ok(ApiResponse.onSuccess("Logged out"));
     }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/controller/AuthController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/controller/AuthController.java
@@ -1,0 +1,38 @@
+package com.leets.backend.blog.controller;
+
+import com.leets.backend.blog.dto.auth.*;
+import com.leets.backend.blog.common.ApiResponse;
+import com.leets.backend.blog.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final AuthService authService;
+    public AuthController(AuthService authService) { this.authService = authService; }
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@RequestBody SignUpRequest req) {
+        authService.signup(req);
+        return ResponseEntity.ok(new ApiResponse(true, "User registered"));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest req) {
+        TokenResponse tokens = authService.login(req);
+        return ResponseEntity.ok(tokens);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@RequestBody RefreshTokenRequest rreq) {
+        TokenResponse tokens = authService.refreshToken(rreq.getRefreshToken());
+        return ResponseEntity.ok(tokens);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@RequestParam String email) {
+        authService.logout(email);
+        return ResponseEntity.ok(new ApiResponse(true, "Logged out"));
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/controller/CommentController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/controller/CommentController.java
@@ -1,66 +1,58 @@
-//package com.leets.backend.blog.controller;
-//
-//import com.leets.backend.blog.common.ApiResponse;
-//import com.leets.backend.blog.dto.CommentCreateRequest;
-//import com.leets.backend.blog.dto.CommentResponse;
-//import com.leets.backend.blog.dto.CommentUpdateRequest;
-//import com.leets.backend.blog.service.CommentService;
-//import io.swagger.v3.oas.annotations.Operation;
-//import io.swagger.v3.oas.annotations.tags.Tag;
-//import jakarta.validation.Valid;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.*;
-//
-//@Tag(name = "Comment API", description = "댓글 관련 API")
-//@RestController
-//@RequestMapping("/posts/{postId}/comments")
-//public class CommentController {
-//
-//    private final CommentService commentService;
-//
-//    public CommentController(CommentService commentService) {
-//        this.commentService = commentService;
-//    }
-//
-//    // 댓글 생성
-//    @Operation(summary = "댓글 생성", description = "새로운 댓글을 생성합니다.")
-//    @PostMapping
-//    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
-//            @PathVariable Long postId, @Valid @RequestBody CommentCreateRequest request
-//    ) {
-//        CommentResponse responseDTO = commentService.createComment(postId, request);
-//
-//        // 201 Created 반환
-//        return new ResponseEntity<>(
-//                ApiResponse.onSuccess(HttpStatus.CREATED, "댓글 생성 완료", responseDTO),
-//                HttpStatus.CREATED
-//        );
-//    }
-//
-//    // 댓글 수정
-//    @Operation(summary = "댓글 수정", description = "댓글 내용을 수정합니다.")
-//    @PatchMapping("/{commentId}")
-//    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(
-//            @PathVariable Long postId, @PathVariable Long commentId, @Valid @RequestBody CommentUpdateRequest request
-//    ) {
-//        CommentResponse responseDTO = commentService.updateComment(postId, commentId, request);
-//
-//        return ResponseEntity.ok(ApiResponse.onSuccess(HttpStatus.OK, "댓글 수정 완료", response));
-//    }
-//
-//    // 댓글 삭제
-//    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
-//    @DeleteMapping("/{commentId}")
-//    public ResponseEntity<ApiResponse<Void>> deleteComment(
-//            @PathVariable Long postId, @PathVariable Long commentId
-//    ) {
-//        commentService.deleteComment(postId, commentId);
-//
-//        // 204 No Content 반환
-//        return new ResponseEntity<>(
-//                ApiResponse.onSuccess(HttpStatus.NO_CONTENT, "댓글 삭제 완료"),
-//                HttpStatus.NO_CONTENT
-//        );
-//    }
-//}
+package com.leets.backend.blog.controller;
+
+import com.leets.backend.blog.common.ApiResponse;
+import com.leets.backend.blog.dto.CommentCreateRequest;
+import com.leets.backend.blog.dto.CommentResponse;
+import com.leets.backend.blog.dto.CommentUpdateRequest;
+import com.leets.backend.blog.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Comment API", description = "댓글 관련 API")
+@RestController
+@RequestMapping("/posts/{postId}/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    @Operation(summary = "댓글 생성", description = "새로운 댓글을 생성합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+            @PathVariable Long postId, @Valid @RequestBody CommentCreateRequest request
+    ) {
+        CommentResponse response = commentService.createComment(postId, request);
+        return new ResponseEntity<>(
+                ApiResponse.onSuccess(HttpStatus.CREATED, "댓글 생성 완료", response),
+                HttpStatus.CREATED
+        );
+    }
+
+    @Operation(summary = "댓글 수정", description = "댓글 내용을 수정합니다.")
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(
+            @PathVariable Long postId, @PathVariable Long commentId, @Valid @RequestBody CommentUpdateRequest request
+    ) {
+        CommentResponse response = commentService.updateComment(postId, commentId, request);
+        return ResponseEntity.ok(ApiResponse.onSuccess(HttpStatus.OK, "댓글 수정 완료", response));
+    }
+
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @PathVariable Long postId, @PathVariable Long commentId
+    ) {
+        commentService.deleteComment(postId, commentId);
+        return new ResponseEntity<>(
+                ApiResponse.onSuccess(HttpStatus.NO_CONTENT, "댓글 삭제 완료",null),
+                HttpStatus.NO_CONTENT
+        );
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/controller/CommentController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/controller/CommentController.java
@@ -1,0 +1,66 @@
+//package com.leets.backend.blog.controller;
+//
+//import com.leets.backend.blog.common.ApiResponse;
+//import com.leets.backend.blog.dto.CommentCreateRequest;
+//import com.leets.backend.blog.dto.CommentResponse;
+//import com.leets.backend.blog.dto.CommentUpdateRequest;
+//import com.leets.backend.blog.service.CommentService;
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import jakarta.validation.Valid;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.*;
+//
+//@Tag(name = "Comment API", description = "댓글 관련 API")
+//@RestController
+//@RequestMapping("/posts/{postId}/comments")
+//public class CommentController {
+//
+//    private final CommentService commentService;
+//
+//    public CommentController(CommentService commentService) {
+//        this.commentService = commentService;
+//    }
+//
+//    // 댓글 생성
+//    @Operation(summary = "댓글 생성", description = "새로운 댓글을 생성합니다.")
+//    @PostMapping
+//    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+//            @PathVariable Long postId, @Valid @RequestBody CommentCreateRequest request
+//    ) {
+//        CommentResponse responseDTO = commentService.createComment(postId, request);
+//
+//        // 201 Created 반환
+//        return new ResponseEntity<>(
+//                ApiResponse.onSuccess(HttpStatus.CREATED, "댓글 생성 완료", responseDTO),
+//                HttpStatus.CREATED
+//        );
+//    }
+//
+//    // 댓글 수정
+//    @Operation(summary = "댓글 수정", description = "댓글 내용을 수정합니다.")
+//    @PatchMapping("/{commentId}")
+//    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(
+//            @PathVariable Long postId, @PathVariable Long commentId, @Valid @RequestBody CommentUpdateRequest request
+//    ) {
+//        CommentResponse responseDTO = commentService.updateComment(postId, commentId, request);
+//
+//        return ResponseEntity.ok(ApiResponse.onSuccess(HttpStatus.OK, "댓글 수정 완료", response));
+//    }
+//
+//    // 댓글 삭제
+//    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+//    @DeleteMapping("/{commentId}")
+//    public ResponseEntity<ApiResponse<Void>> deleteComment(
+//            @PathVariable Long postId, @PathVariable Long commentId
+//    ) {
+//        commentService.deleteComment(postId, commentId);
+//
+//        // 204 No Content 반환
+//        return new ResponseEntity<>(
+//                ApiResponse.onSuccess(HttpStatus.NO_CONTENT, "댓글 삭제 완료"),
+//                HttpStatus.NO_CONTENT
+//        );
+//    }
+//}

--- a/blog_manage/src/main/java/com/leets/backend/blog/controller/KakaoAuthController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/controller/KakaoAuthController.java
@@ -1,6 +1,5 @@
 package com.leets.backend.blog.controller;
 
-import com.leets.backend.blog.dto.kakao.KakaoLoginRequest;
 import com.leets.backend.blog.dto.kakao.KakaoLoginResponse;
 import com.leets.backend.blog.service.KakaoAuthService;
 import com.leets.backend.blog.service.RefreshTokenService;
@@ -17,22 +16,42 @@ public class KakaoAuthController {
     private final KakaoAuthService kakaoAuthService;
     private final RefreshTokenService tokenService;
 
-    public KakaoAuthController(KakaoAuthService kakaoAuthService, RefreshTokenService refreshTokenService) {
+    public KakaoAuthController(KakaoAuthService kakaoAuthService, RefreshTokenService tokenService) {
         this.kakaoAuthService = kakaoAuthService;
-        this.tokenService = refreshTokenService;
+        this.tokenService = tokenService;
     }
 
-    // 카카오 로그인 처리
-    @PostMapping("/login")
-    public ResponseEntity<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request) {
-        KakaoLoginResponse response = kakaoAuthService.kakaoLogin(request.getAccessToken());
+    /**
+     * ① 카카오 로그인 URL 제공
+     * 프론트가 이 URL을 받아서 카카오 로그인 창으로 이동함
+     */
+    @GetMapping("/login-url")
+    public ResponseEntity<Map<String, String>> getKakaoLoginUrl() {
+        String loginUrl = kakaoAuthService.getKakaoLoginUrl();
+
+        Map<String, String> response = new HashMap<>();
+        response.put("loginUrl", loginUrl);
+
         return ResponseEntity.ok(response);
     }
 
-    // Refresh Token으로 새로운 Access Token 발급
+    /**
+     * ② 카카오 redirect_uri 에서 받는 callback
+     * 카카오가 인가코드(code)를 주면 백엔드가 이를 기반으로 로그인 수행
+     */
+    @GetMapping("/callback")
+    public ResponseEntity<KakaoLoginResponse> kakaoCallback(@RequestParam("code") String code) {
+        KakaoLoginResponse response = kakaoAuthService.loginWithCode(code);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * ③ Refresh Token을 이용해 Access Token 재발급
+     */
     @PostMapping("/refresh")
     public ResponseEntity<Map<String, String>> refresh(@RequestBody Map<String, String> request) {
         String refreshToken = request.get("refreshToken");
+
         String newAccessToken = tokenService.refreshAccessToken(refreshToken);
 
         Map<String, String> response = new HashMap<>();

--- a/blog_manage/src/main/java/com/leets/backend/blog/controller/KakaoAuthController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/controller/KakaoAuthController.java
@@ -1,0 +1,43 @@
+package com.leets.backend.blog.controller;
+
+import com.leets.backend.blog.dto.kakao.KakaoLoginRequest;
+import com.leets.backend.blog.dto.kakao.KakaoLoginResponse;
+import com.leets.backend.blog.service.KakaoAuthService;
+import com.leets.backend.blog.service.RefreshTokenService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth/kakao")
+public class KakaoAuthController {
+
+    private final KakaoAuthService kakaoAuthService;
+    private final RefreshTokenService tokenService;
+
+    public KakaoAuthController(KakaoAuthService kakaoAuthService, RefreshTokenService refreshTokenService) {
+        this.kakaoAuthService = kakaoAuthService;
+        this.tokenService = refreshTokenService;
+    }
+
+    // 카카오 로그인 처리
+    @PostMapping("/login")
+    public ResponseEntity<KakaoLoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request) {
+        KakaoLoginResponse response = kakaoAuthService.kakaoLogin(request.getAccessToken());
+        return ResponseEntity.ok(response);
+    }
+
+    // Refresh Token으로 새로운 Access Token 발급
+    @PostMapping("/refresh")
+    public ResponseEntity<Map<String, String>> refresh(@RequestBody Map<String, String> request) {
+        String refreshToken = request.get("refreshToken");
+        String newAccessToken = tokenService.refreshAccessToken(refreshToken);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("accessToken", newAccessToken);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/controller/PostController.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/controller/PostController.java
@@ -1,13 +1,20 @@
 package com.leets.backend.blog.controller;
 
 import com.leets.backend.blog.dto.PostCreateRequest;
+import com.leets.backend.blog.dto.PostResponse;
 import com.leets.backend.blog.dto.PostUpdateRequest;
-import com.leets.backend.blog.entity.Post;
 import com.leets.backend.blog.service.PostService;
+import com.leets.backend.blog.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Post API", description = "게시물 관련 API")
 @RestController
 @RequestMapping("/api/posts")
 public class PostController {
@@ -18,33 +25,60 @@ public class PostController {
         this.postService = postService;
     }
 
-    // 게시글 전체 조회
+    // 게시물 목록 조회
+    @Operation(summary = "게시물 목록 조회", description = "게시물 목록을 조회합니다.")
     @GetMapping
-    public List<Post> getAllPosts() {
-        return postService.findAll();
+    public ResponseEntity<ApiResponse<List<PostResponse>>> getAllPosts() {
+        List<PostResponse> posts = postService.findAll();
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(HttpStatus.OK, "게시물 목록 조회 완료", posts)
+        );
     }
 
-    // 게시글 상세 조회
-    @GetMapping("/{id}")
-    public Post getPostById(@PathVariable Long id) {
-        return postService.findById(id);
+    // 게시물 상세 조회
+    @Operation(summary = "게시물 상세 조회", description = "특정 게시물을 조회합니다.")
+    @GetMapping("/{postId}")
+    public ResponseEntity<ApiResponse<PostResponse>> getPostDetail(@PathVariable Long postId) {
+        PostResponse response = postService.findById(postId);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(HttpStatus.OK, "게시물 상세 조회 완료", response)
+        );
     }
 
-    // 게시글 작성 (PostCreateRequest 사용)
+    // 게시물 생성
+    @Operation(summary = "게시물 생성", description = "새로운 게시물을 생성합니다.")
     @PostMapping
-    public Post createPost(@RequestBody PostCreateRequest request) {
-        return postService.createPost(request);
+    public ResponseEntity<ApiResponse<PostResponse>> createPost(
+            @Valid @RequestBody PostCreateRequest request
+    ) {
+        PostResponse response = postService.createPost(request);
+        return new ResponseEntity<>(
+                ApiResponse.onSuccess(HttpStatus.CREATED, "게시물 생성 완료", response),
+                HttpStatus.CREATED
+        );
     }
 
-    // 게시글 수정 (PostUpdateRequest 사용)
+    // 게시물 수정
+    @Operation(summary = "게시물 수정", description = "게시물 내용을 수정합니다.")
     @PutMapping("/{id}")
-    public Post updatePost(@PathVariable Long id, @RequestBody PostUpdateRequest request) {
-        return postService.updatePost(id, request);
+    public ResponseEntity<ApiResponse<PostResponse>> updatePost(
+            @PathVariable Long id,
+            @RequestBody PostUpdateRequest request
+    ) {
+        PostResponse response = postService.updatePost(id, request);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(HttpStatus.OK, "게시물 수정 완료", response)
+        );
     }
 
-    // 게시글 삭제
+    // 게시물 삭제
+    @Operation(summary = "게시물 삭제", description = "게시물을 삭제합니다.")
     @DeleteMapping("/{id}")
-    public void deletePost(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long id) {
         postService.deletePost(id);
+        return new ResponseEntity<>(
+                ApiResponse.onSuccess(HttpStatus.NO_CONTENT, "게시물 삭제 완료", null),
+                HttpStatus.NO_CONTENT
+        );
     }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentCreateRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentCreateRequest.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog.dto;
+
+public class CommentCreateRequest {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentCreateRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentCreateRequest.java
@@ -1,4 +1,13 @@
 package com.leets.backend.blog.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public class CommentCreateRequest {
+    @NotBlank(message = "댓글 내용은 비워둘 수 없습니다.")
+    private String content;
+
+    public CommentCreateRequest() { }
+
+    // getters
+    public String getContent() { return content; }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentResponse.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentResponse.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog.dto;
+
+public class CommentResponse {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentResponse.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentResponse.java
@@ -21,4 +21,19 @@ public class CommentResponse {
 
         return response;
     }
+    public Long getCommentId() {
+        return commentId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentResponse.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentResponse.java
@@ -1,4 +1,24 @@
 package com.leets.backend.blog.dto;
 
+import com.leets.backend.blog.entity.Comment;
+
+import java.time.LocalDateTime;
+
 public class CommentResponse {
+    private Long commentId;
+    private String content;
+    private String nickname;
+    private LocalDateTime createdAt;
+
+    public CommentResponse() {}
+    public static CommentResponse from(Comment comment) {
+        CommentResponse response = new CommentResponse();
+
+        response.commentId = comment.getCommentId();
+        response.content = comment.getContent();
+        response.nickname = comment.getUser().getNickname();
+        response.createdAt = comment.getCreatedAt();
+
+        return response;
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentUpdateRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentUpdateRequest.java
@@ -1,4 +1,12 @@
 package com.leets.backend.blog.dto;
+import jakarta.validation.constraints.NotBlank;
 
 public class CommentUpdateRequest {
+    @NotBlank(message = "댓글 내용은 비워둘 수 없습니다.")
+    private String content;
+
+    public CommentUpdateRequest() { }
+
+    //getters
+    public String getContent() { return content; }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentUpdateRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/CommentUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog.dto;
+
+public class CommentUpdateRequest {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/auth/LoginRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/auth/LoginRequest.java
@@ -1,0 +1,28 @@
+package com.leets.backend.blog.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+
+    public LoginRequest() {}
+
+    public LoginRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    // getters / setters
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/auth/RefreshTokenRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/auth/RefreshTokenRequest.java
@@ -1,0 +1,13 @@
+package com.leets.backend.blog.dto.auth;
+
+public class RefreshTokenRequest {
+    private String refreshToken;
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/auth/SignUpRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/auth/SignUpRequest.java
@@ -1,0 +1,56 @@
+package com.leets.backend.blog.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class SignUpRequest {
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    @Size(min = 6, message = "password must be at least 6 characters")
+    private String password;
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String nickname;
+
+    public SignUpRequest() {}
+
+    public SignUpRequest(String email, String password, String name, String nickname) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.nickname = nickname;
+    }
+
+    // getters / setters
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getNickname() { return nickname; }
+    public void setNickname(String nickname) { this.nickname = nickname; }
+
+    public static class RefreshTokenRequest {
+        @NotBlank
+        private String refreshToken;
+
+        public RefreshTokenRequest() {}
+
+        public RefreshTokenRequest(String refreshToken) { this.refreshToken = refreshToken; }
+
+        public String getRefreshToken() { return refreshToken; }
+        public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/auth/TokenResponse.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/auth/TokenResponse.java
@@ -1,0 +1,25 @@
+package com.leets.backend.blog.dto.auth;
+
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+    private long accessTokenExpiresIn; // ms 남은 시간 or 만료 epoch 등 필요에 따라 수정
+
+    public TokenResponse() {}
+
+    public TokenResponse(String accessToken, String refreshToken, long accessTokenExpiresIn) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.accessTokenExpiresIn = accessTokenExpiresIn;
+    }
+
+    // getters / setters
+    public String getAccessToken() { return accessToken; }
+    public void setAccessToken(String accessToken) { this.accessToken = accessToken; }
+
+    public String getRefreshToken() { return refreshToken; }
+    public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
+
+    public long getAccessTokenExpiresIn() { return accessTokenExpiresIn; }
+    public void setAccessTokenExpiresIn(long accessTokenExpiresIn) { this.accessTokenExpiresIn = accessTokenExpiresIn; }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/kakao/KakaoLoginRequest.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/kakao/KakaoLoginRequest.java
@@ -1,0 +1,21 @@
+package com.leets.backend.blog.dto.kakao;
+
+public class KakaoLoginRequest {
+
+    private String accessToken;
+
+    public KakaoLoginRequest() {
+    }
+
+    public KakaoLoginRequest(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/dto/kakao/KakaoLoginResponse.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/dto/kakao/KakaoLoginResponse.java
@@ -1,0 +1,51 @@
+package com.leets.backend.blog.dto.kakao;
+
+public class KakaoLoginResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private String email;
+    private String nickname;
+
+    public KakaoLoginResponse() {
+    }
+
+    public KakaoLoginResponse(String accessToken, String refreshToken, String email, String nickname) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.email = email;
+        this.nickname = nickname;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/entity/Comment.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/entity/Comment.java
@@ -26,6 +26,21 @@ public class Comment {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    protected Comment() {}
+
+    public static Comment createComment(String content, User user, Post post) {
+        Comment comment = new Comment();
+        comment.content = content;
+        comment.user = user;
+        comment.post = post;
+        comment.createdAt = LocalDateTime.now();
+        return comment;
+    }
+
+    public void updateComment(String newContent) {
+        this.content = newContent;
+    }
+
     // Getters
     public Long getCommentId() {
         return commentId;

--- a/blog_manage/src/main/java/com/leets/backend/blog/entity/RefreshToken.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/entity/RefreshToken.java
@@ -1,0 +1,40 @@
+package com.leets.backend.blog.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "userId")
+    private User user;
+
+    @Column(nullable = false)
+    private Instant expiryDate;
+
+    public RefreshToken() {}
+
+    public RefreshToken(String token, User user, Instant expiryDate) {
+        this.token = token;
+        this.user = user;
+        this.expiryDate = expiryDate;
+    }
+
+    public Long getId() { return id; }
+    public String getToken() { return token; }
+    public User getUser() { return user; }
+    public Instant getExpiryDate() { return expiryDate; }
+
+    public void setToken(String token) { this.token = token; }
+    public void setUser(User user) { this.user = user; }
+    public void setExpiryDate(Instant expiryDate) { this.expiryDate = expiryDate; }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/entity/User.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/entity/User.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "users")
+@Table(name = "user")
 public class User {
 
     @Id

--- a/blog_manage/src/main/java/com/leets/backend/blog/entity/User.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/entity/User.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "user")
+@Table(name = "users") // 'user' 대신 'users' 권장
 public class User {
 
     @Id
@@ -13,7 +13,7 @@ public class User {
     private Long userId;
 
     @Column(nullable = false, unique = true)
-    private String email;
+    private String email; // 로그인 ID (email)
 
     @Column(nullable = false)
     private String name;
@@ -21,6 +21,7 @@ public class User {
     @Column(nullable = false)
     private String nickname;
 
+    // password는 OAuth 사용자 등에서 null일 수 있으므로 nullable = true 허용
     @Column(nullable = true)
     private String password;
 
@@ -39,8 +40,20 @@ public class User {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    // 권한(ROLE_USER 등)
+    @Column(nullable = false)
+    private String role = "ROLE_USER";
+
     public User() {}
 
+    // 회원가입 등에서 쓸 생성자
+    public User(String email, String password, String name, String nickname, String role) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.nickname = nickname;
+        this.role = role != null ? role : "ROLE_USER";
+    }
 
     @PrePersist
     protected void onCreate() {
@@ -64,21 +77,19 @@ public class User {
     public LocalDateTime getBirth() { return birth; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public String getRole() { return role; }
 
-    // Setter / 업데이트 관련 메서드
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
-    }
+    // Setter
+    public void setEmail(String email) { this.email = email; }
+    public void setName(String name) { this.name = name; }
+    public void setNickname(String nickname) { this.nickname = nickname; }
+    public void setPassword(String password) { this.password = password; }
+    public void setIntroduction(String introduction) { this.introduction = introduction; }
+    public void setKakaoId(String kakaoId) { this.kakaoId = kakaoId; }
+    public void setBirth(LocalDateTime birth) { this.birth = birth; }
+    public void setRole(String role) { this.role = role; }
 
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public void setIntroduction(String introduction) {
-        this.introduction = introduction;
-    }
-
-
+    // 업데이트 편의 메서드
     public void update(String nickname, String password, String introduction) {
         if (nickname != null && !nickname.isBlank()) {
             this.nickname = nickname;
@@ -91,7 +102,6 @@ public class User {
         }
         this.updatedAt = LocalDateTime.now();
     }
-
 
     public static User createDummy() {
         User user = new User();

--- a/blog_manage/src/main/java/com/leets/backend/blog/entity/User.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/entity/User.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "users") // 'user' 대신 'users' 권장
+@Table(name = "users")
 public class User {
 
     @Id
@@ -21,15 +21,19 @@ public class User {
     @Column(nullable = false)
     private String nickname;
 
-    // password는 OAuth 사용자 등에서 null일 수 있으므로 nullable = true 허용
     @Column(nullable = true)
     private String password;
 
     @Column(nullable = true)
     private String introduction;
 
+    // 소셜 로그인 식별자
+    @Column(nullable = true, unique = true)
+    private String socialId;
+
+    // 로그인 제공자 구분
     @Column(nullable = true)
-    private String kakaoId;
+    private String provider;
 
     @Column(nullable = true)
     private LocalDateTime birth;
@@ -73,7 +77,8 @@ public class User {
     public String getNickname() { return nickname; }
     public String getPassword() { return password; }
     public String getIntroduction() { return introduction; }
-    public String getKakaoId() { return kakaoId; }
+    public String getSocialId() { return socialId; }
+    public String getProvider() { return provider; }
     public LocalDateTime getBirth() { return birth; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
@@ -85,7 +90,8 @@ public class User {
     public void setNickname(String nickname) { this.nickname = nickname; }
     public void setPassword(String password) { this.password = password; }
     public void setIntroduction(String introduction) { this.introduction = introduction; }
-    public void setKakaoId(String kakaoId) { this.kakaoId = kakaoId; }
+    public void setSocialId(String socialId) { this.socialId = socialId; }
+    public void setProvider(String provider) { this.provider = provider; }
     public void setBirth(LocalDateTime birth) { this.birth = birth; }
     public void setRole(String role) { this.role = role; }
 

--- a/blog_manage/src/main/java/com/leets/backend/blog/exception/CommentAccessDeniedException.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/exception/CommentAccessDeniedException.java
@@ -1,4 +1,13 @@
 package com.leets.backend.blog.exception;
 
-public class CommentAccessDeniedException {
+public class CommentAccessDeniedException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "이 댓글에 대한 접근 권한이 없습니다. 작성자만 수정 또는 삭제할 수 있습니다.";
+
+    public CommentAccessDeniedException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public CommentAccessDeniedException(String message) {
+        super(message);
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/exception/CommentAccessDeniedException.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/exception/CommentAccessDeniedException.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog.exception;
+
+public class CommentAccessDeniedException {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/exception/CommentNotFoundException.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/exception/CommentNotFoundException.java
@@ -1,0 +1,13 @@
+package com.leets.backend.blog.exception;
+
+public class CommentNotFoundException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "댓글을 찾을 수 없습니다.";
+
+    public CommentNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public CommentNotFoundException(Long commentId) {
+        super(DEFAULT_MESSAGE + " (ID: " + commentId + ")");
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/exception/GlobalExceptionHandler.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/exception/GlobalExceptionHandler.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.HashMap;
 import java.util.Map;
 
-//@RestControllerAdvice
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
     // 400 Bad Request (DTO 검증 실패)
@@ -45,6 +45,7 @@ public class GlobalExceptionHandler {
     // 500 Internal Server Error
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleGeneralException(Exception exception) {
+        exception.printStackTrace();
         return new ResponseEntity<>(
                 ApiResponse.onFailure(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류 발생", null),
                 HttpStatus.INTERNAL_SERVER_ERROR

--- a/blog_manage/src/main/java/com/leets/backend/blog/exception/GlobalExceptionHandler.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/exception/GlobalExceptionHandler.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.HashMap;
 import java.util.Map;
 
-@RestControllerAdvice
+//@RestControllerAdvice
 public class GlobalExceptionHandler {
 
     // 400 Bad Request (DTO 검증 실패)

--- a/blog_manage/src/main/java/com/leets/backend/blog/repository/CommentRepository.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.leets.backend.blog.repository;
+
+import com.leets.backend.blog.entity.Comment;
+import com.leets.backend.blog.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/repository/RefreshTokenRepository.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.leets.backend.blog.repository;
+
+import com.leets.backend.blog.entity.RefreshToken;
+import com.leets.backend.blog.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByUser(User user);
+    void deleteByUser(User user);
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/repository/UserRepository.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/repository/UserRepository.java
@@ -4,7 +4,10 @@ import com.leets.backend.blog.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    User findByEmail(String email);
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/repository/UserRepository.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/repository/UserRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
+    Optional<User> findBySocialId(String socialId);
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/AuthService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/AuthService.java
@@ -1,0 +1,110 @@
+package com.leets.backend.blog.service;
+
+import com.leets.backend.blog.config.JwtTokenProvider;
+import com.leets.backend.blog.dto.auth.*;
+import com.leets.backend.blog.entity.RefreshToken;
+import com.leets.backend.blog.entity.User;
+import com.leets.backend.blog.repository.RefreshTokenRepository;
+import com.leets.backend.blog.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Date;
+
+@Service
+public class AuthService {
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // authenticationManager는 현재 사용하지 않으므로 제거(필요하면 다시 추가)
+    public AuthService(UserRepository userRepository,
+                       RefreshTokenRepository refreshTokenRepository,
+                       PasswordEncoder passwordEncoder,
+                       JwtTokenProvider jwtTokenProvider) {
+        this.userRepository = userRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    // 회원가입
+    public void signup(SignUpRequest req) {
+        if (userRepository.existsByEmail(req.getEmail())) {
+            throw new RuntimeException("Email already in use");
+        }
+
+        String encoded = passwordEncoder.encode(req.getPassword());
+
+        User user = new User(
+                req.getEmail(),
+                encoded,
+                req.getName(),
+                req.getNickname(),
+                "ROLE_USER"
+        );
+
+        userRepository.save(user);
+    }
+
+    public TokenResponse login(LoginRequest req) {
+        User user = userRepository.findByEmail(req.getEmail())
+                .orElseThrow(() -> new RuntimeException("Invalid credentials"));
+
+        if (!passwordEncoder.matches(req.getPassword(), user.getPassword())) {
+            throw new RuntimeException("Invalid credentials");
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole());
+        String refreshTokenString = jwtTokenProvider.createRefreshToken(user.getEmail());
+
+        // 기존 엔티티가 있으면 가져오고, 없으면 새 엔티티 생성
+        RefreshToken tokenEntity = refreshTokenRepository.findByUser(user)
+                .orElseGet(RefreshToken::new);
+
+        tokenEntity.setToken(refreshTokenString);
+        tokenEntity.setUser(user);
+
+        // jwtTokenProvider.getExpiration(...)이 Date를 반환한다고 가정
+        tokenEntity.setExpiryDate(
+                Instant.ofEpochMilli(jwtTokenProvider.getExpiration(refreshTokenString).getTime())
+        );
+
+        refreshTokenRepository.save(tokenEntity);
+
+        long expiresIn = jwtTokenProvider.getExpiration(accessToken).getTime() - new Date().getTime();
+        return new TokenResponse(accessToken, refreshTokenString, expiresIn);
+    }
+
+    public TokenResponse refreshToken(String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new RuntimeException("Invalid refresh token");
+        }
+
+        String email = jwtTokenProvider.getSubject(refreshToken);
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        RefreshToken stored = refreshTokenRepository.findByUser(user)
+                .orElseThrow(() -> new RuntimeException("Refresh token not found"));
+
+        // NPE 방지: equals 호출은 외부(인자) 문자열에서 수행 -> 안전하게 비교
+        if (!refreshToken.equals(stored.getToken()) || stored.getExpiryDate().isBefore(Instant.now())) {
+            throw new RuntimeException("Refresh token invalid or expired");
+        }
+
+        String newAccess = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole());
+        long expiresIn = jwtTokenProvider.getExpiration(newAccess).getTime() - new Date().getTime();
+
+        return new TokenResponse(newAccess, refreshToken, expiresIn);
+    }
+
+    // 로그아웃: 해당 유저의 리프레시 토큰 삭제
+    public void logout(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        refreshTokenRepository.deleteByUser(user);
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/AuthService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/AuthService.java
@@ -19,7 +19,6 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
-    // authenticationManager는 현재 사용하지 않으므로 제거(필요하면 다시 추가)
     public AuthService(UserRepository userRepository,
                        RefreshTokenRepository refreshTokenRepository,
                        PasswordEncoder passwordEncoder,
@@ -66,8 +65,6 @@ public class AuthService {
 
         tokenEntity.setToken(refreshTokenString);
         tokenEntity.setUser(user);
-
-        // jwtTokenProvider.getExpiration(...)이 Date를 반환한다고 가정
         tokenEntity.setExpiryDate(
                 Instant.ofEpochMilli(jwtTokenProvider.getExpiration(refreshTokenString).getTime())
         );

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/CommentService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/CommentService.java
@@ -18,23 +18,27 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 public class CommentService {
+
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
 
     private static final String DUMMY_USER_EMAIL = "dummy@naver.com";
 
-    public CommentService(CommentRepository commentRepository, PostRepository postRepository, UserRepository userRepository) {
+    public CommentService(CommentRepository commentRepository,
+                          PostRepository postRepository,
+                          UserRepository userRepository) {
         this.commentRepository = commentRepository;
         this.postRepository = postRepository;
         this.userRepository = userRepository;
     }
 
-    //댓글 생성
+    // 댓글 생성
     public CommentResponse createComment(Long postId, CommentCreateRequest request) {
-        User user = findDummyUser();
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new PostNotFoundException(postId));
+        User user = findOrCreateDummyUser();
+
+        // 게시글 존재 확인
+        Post post = findPostById(postId);
 
         Comment comment = Comment.createComment(request.getContent(), user, post);
         commentRepository.save(comment);
@@ -42,62 +46,69 @@ public class CommentService {
         return CommentResponse.from(comment);
     }
 
-    //댓글 수정
+    // 댓글 수정
     public CommentResponse updateComment(Long postId, Long commentId, CommentUpdateRequest request) {
-        User user = findDummyUser();
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new PostNotFoundException(postId));
+        User user = findOrCreateDummyUser();
 
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new CommentNotFoundException(commentId));
-
-        if (!comment.getPost().getPostId().equals(post.getPostId())) {
-            throw new CommentNotFoundException(commentId);
-        }
-
-        // 권한 확인
-        checkCommentAuthor(comment, user);
+        // 댓글 조회 및 검증 (게시글, 댓글 존재, 작성자 확인)
+        Comment comment = validateCommentAccess(postId, commentId, user);
 
         comment.updateComment(request.getContent());
         return CommentResponse.from(comment);
     }
 
-    //댓글 삭제
+    // 댓글 삭제
     public void deleteComment(Long postId, Long commentId) {
-        User user = findDummyUser();
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new PostNotFoundException(postId));
+        User user = findOrCreateDummyUser();
 
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new CommentNotFoundException(commentId));
-
-        // (선택) 방어적 게시글 검증
-        if (!comment.getPost().getPostId().equals(post.getPostId())) {
-            throw new CommentNotFoundException(commentId);
-        }
-
-        // 권한 확인
-        checkCommentAuthor(comment, user);
+        // 댓글 조회 및 검증 (게시글, 댓글 존재, 작성자 확인)
+        Comment comment = validateCommentAccess(postId, commentId, user);
 
         commentRepository.delete(comment);
     }
 
-    // 더미 유저 생성
+
+    // 더미 유저가 없으면 생성하고, 있으면 반환
+    private User findOrCreateDummyUser() {
+        return userRepository.findByEmail(DUMMY_USER_EMAIL)
+                .orElseGet(this::createDummyUser);
+    }
+
+    // 더미 유저를 DB에 생성 (이미 존재하면 중복 예외 방지)
     private User createDummyUser() {
-        User user = new User();
-        return userRepository.save(user.createDummy());
+        User dummy = User.createDummy();
+
+        // 혹시 병렬 요청 등으로 이미 생성되어 있을 경우 방어
+        return userRepository.findByEmail(DUMMY_USER_EMAIL)
+                .orElseGet(() -> userRepository.save(dummy));
     }
 
-    // 더미 유저 조회 (없으면 생성)
-    private User findDummyUser() {
-        User user = userRepository.findByEmail(DUMMY_USER_EMAIL);
-        if (user == null) {
-            user = createDummyUser();
+    // 게시글 ID로 게시글을 찾아 반환하고, 없으면 예외 발생
+    private Post findPostById(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+    }
+
+    private Comment validateCommentAccess(Long postId, Long commentId, User user) {
+        // 게시글 존재 확인
+        findPostById(postId);
+
+        // 댓글 존재 확인
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        // 댓글의 게시글 일치 여부 확인
+        if (!comment.getPost().getPostId().equals(postId)) {
+            throw new CommentNotFoundException(commentId);
         }
-        return user;
+
+        // 작성자 검증
+        checkCommentAuthor(comment, user);
+
+        return comment;
     }
 
-    // 댓글 작성자 권한 확인
+    // 댓글 작성자 검증
     private void checkCommentAuthor(Comment comment, User user) {
         if (!comment.getUser().getUserId().equals(user.getUserId())) {
             throw new CommentAccessDeniedException();

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/CommentService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/CommentService.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog.service;
+
+public class CommentService {
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/CommentService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/CommentService.java
@@ -1,4 +1,106 @@
 package com.leets.backend.blog.service;
 
+import com.leets.backend.blog.dto.CommentCreateRequest;
+import com.leets.backend.blog.dto.CommentResponse;
+import com.leets.backend.blog.dto.CommentUpdateRequest;
+import com.leets.backend.blog.entity.Comment;
+import com.leets.backend.blog.entity.Post;
+import com.leets.backend.blog.entity.User;
+import com.leets.backend.blog.exception.CommentAccessDeniedException;
+import com.leets.backend.blog.exception.CommentNotFoundException;
+import com.leets.backend.blog.exception.PostNotFoundException;
+import com.leets.backend.blog.repository.CommentRepository;
+import com.leets.backend.blog.repository.PostRepository;
+import com.leets.backend.blog.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
 public class CommentService {
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    private static final String DUMMY_USER_EMAIL = "dummy@naver.com";
+
+    public CommentService(CommentRepository commentRepository, PostRepository postRepository, UserRepository userRepository) {
+        this.commentRepository = commentRepository;
+        this.postRepository = postRepository;
+        this.userRepository = userRepository;
+    }
+
+    //댓글 생성
+    public CommentResponse createComment(Long postId, CommentCreateRequest request) {
+        User user = findDummyUser();
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        Comment comment = Comment.createComment(request.getContent(), user, post);
+        commentRepository.save(comment);
+
+        return CommentResponse.from(comment);
+    }
+
+    //댓글 수정
+    public CommentResponse updateComment(Long postId, Long commentId, CommentUpdateRequest request) {
+        User user = findDummyUser();
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        if (!comment.getPost().getPostId().equals(post.getPostId())) {
+            throw new CommentNotFoundException(commentId);
+        }
+
+        // 권한 확인
+        checkCommentAuthor(comment, user);
+
+        comment.updateComment(request.getContent());
+        return CommentResponse.from(comment);
+    }
+
+    //댓글 삭제
+    public void deleteComment(Long postId, Long commentId) {
+        User user = findDummyUser();
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        // (선택) 방어적 게시글 검증
+        if (!comment.getPost().getPostId().equals(post.getPostId())) {
+            throw new CommentNotFoundException(commentId);
+        }
+
+        // 권한 확인
+        checkCommentAuthor(comment, user);
+
+        commentRepository.delete(comment);
+    }
+
+    // 더미 유저 생성
+    private User createDummyUser() {
+        User user = new User();
+        return userRepository.save(user.createDummy());
+    }
+
+    // 더미 유저 조회 (없으면 생성)
+    private User findDummyUser() {
+        User user = userRepository.findByEmail(DUMMY_USER_EMAIL);
+        if (user == null) {
+            user = createDummyUser();
+        }
+        return user;
+    }
+
+    // 댓글 작성자 권한 확인
+    private void checkCommentAuthor(Comment comment, User user) {
+        if (!comment.getUser().getUserId().equals(user.getUserId())) {
+            throw new CommentAccessDeniedException();
+        }
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/CustomUserDetailsService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.leets.backend.blog.service;
+
+import com.leets.backend.blog.entity.User;
+import com.leets.backend.blog.repository.UserRepository;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.stereotype.Service;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+
+import java.util.Collections;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+    public CustomUserDetailsService(UserRepository repo) { this.userRepository = repo; }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + email));
+        return new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPassword(),
+                Collections.singletonList(new SimpleGrantedAuthority(user.getRole()))
+        );
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/KakaoAuthService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/KakaoAuthService.java
@@ -1,0 +1,94 @@
+package com.leets.backend.blog.service;
+
+import com.leets.backend.blog.dto.kakao.KakaoLoginResponse;
+import com.leets.backend.blog.entity.RefreshToken;
+import com.leets.backend.blog.entity.User;
+import com.leets.backend.blog.repository.RefreshTokenRepository;
+import com.leets.backend.blog.repository.UserRepository;
+import com.leets.backend.blog.config.JwtTokenProvider;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Service
+public class KakaoAuthService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RestTemplate restTemplate;
+
+    // 예시: Refresh Token 유효기간 (7일)
+    private static final long REFRESH_TOKEN_EXPIRY_SECONDS = 7 * 24 * 60 * 60;
+
+    public KakaoAuthService(UserRepository userRepository,
+                            RefreshTokenRepository refreshTokenRepository,
+                            JwtTokenProvider jwtTokenProvider) {
+        this.userRepository = userRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.restTemplate = new RestTemplate();
+    }
+
+    public KakaoLoginResponse kakaoLogin(String kakaoAccessToken) {
+
+        // 카카오 API 요청
+        String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + kakaoAccessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<Map> response = restTemplate.exchange(userInfoUrl, HttpMethod.GET, entity, Map.class);
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new RuntimeException("카카오 사용자 정보 요청 실패 (status=" + response.getStatusCode() + ")");
+        }
+
+        Map<String, Object> body = response.getBody();
+        if (body == null) {
+            throw new RuntimeException("카카오 사용자 정보가 비어 있습니다.");
+        }
+
+        String kakaoId = String.valueOf(body.get("id"));
+        Map<String, Object> kakaoAccount = (Map<String, Object>) body.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        String email = kakaoAccount.get("email") != null ? kakaoAccount.get("email").toString() : kakaoId + "@kakao.com";
+        String nickname = (profile != null && profile.get("nickname") != null)
+                ? profile.get("nickname").toString()
+                : "KakaoUser";
+
+        // 사용자 조회/등록
+        User user = userRepository.findBySocialId(kakaoId).orElseGet(() -> {
+            User newUser = new User();
+            newUser.setSocialId(kakaoId);
+            newUser.setEmail(email);
+            newUser.setNickname(nickname);
+            newUser.setProvider("kakao");
+            newUser.setRole("ROLE_USER");
+            return userRepository.save(newUser);
+        });
+
+        // JWT 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole());
+        String refreshTokenValue = jwtTokenProvider.createRefreshToken(user.getEmail());
+
+        // Refresh Token 저장 (기존 토큰 삭제 후 갱신)
+        refreshTokenRepository.deleteByUser(user);
+
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUser(user);
+        refreshToken.setToken(refreshTokenValue);
+        refreshToken.setExpiryDate(Instant.now().plusSeconds(REFRESH_TOKEN_EXPIRY_SECONDS));
+
+        refreshTokenRepository.save(refreshToken);
+
+        System.out.println(" RefreshToken 저장 완료: " + refreshTokenValue);
+
+        return new KakaoLoginResponse(accessToken, refreshTokenValue, email, nickname);
+    }
+}

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/KakaoAuthService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/KakaoAuthService.java
@@ -6,22 +6,40 @@ import com.leets.backend.blog.entity.User;
 import com.leets.backend.blog.repository.RefreshTokenRepository;
 import com.leets.backend.blog.repository.UserRepository;
 import com.leets.backend.blog.config.JwtTokenProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 
 @Service
 public class KakaoAuthService {
 
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${kakao.user-info-uri}")
+    private String userInfoUri;
+
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
-    private final RestTemplate restTemplate;
+    private final RestTemplate restTemplate = new RestTemplate();
 
-    // 예시: Refresh Token 유효기간 (7일)
     private static final long REFRESH_TOKEN_EXPIRY_SECONDS = 7 * 24 * 60 * 60;
 
     public KakaoAuthService(UserRepository userRepository,
@@ -30,39 +48,43 @@ public class KakaoAuthService {
         this.userRepository = userRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.jwtTokenProvider = jwtTokenProvider;
-        this.restTemplate = new RestTemplate();
     }
 
-    public KakaoLoginResponse kakaoLogin(String kakaoAccessToken) {
+    /**
+     * ① 프론트가 이동해야 할 카카오 로그인 URL 생성
+     */
+    public String getKakaoLoginUrl() {
+        return "https://kauth.kakao.com/oauth/authorize" +
+                "?client_id=" + clientId +
+                "&redirect_uri=" + redirectUri +
+                "&response_type=code";
+    }
 
-        // 카카오 API 요청
-        String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + kakaoAccessToken);
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    /**
+     * ② callback의 code로 Access Token 요청 → 사용자 정보 조회 → 회원가입/로그인 처리
+     */
+    public KakaoLoginResponse loginWithCode(String code) {
 
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<Map> response = restTemplate.exchange(userInfoUrl, HttpMethod.GET, entity, Map.class);
+        // (1) code로 Access Token 요청
+        Map<String, String> tokenResponse = requestAccessToken(code);
+        String kakaoAccessToken = tokenResponse.get("access_token");
 
-        if (!response.getStatusCode().is2xxSuccessful()) {
-            throw new RuntimeException("카카오 사용자 정보 요청 실패 (status=" + response.getStatusCode() + ")");
-        }
+        // (2) 사용자 정보 요청
+        Map<String, Object> userInfo = requestUserInfo(kakaoAccessToken);
 
-        Map<String, Object> body = response.getBody();
-        if (body == null) {
-            throw new RuntimeException("카카오 사용자 정보가 비어 있습니다.");
-        }
-
-        String kakaoId = String.valueOf(body.get("id"));
-        Map<String, Object> kakaoAccount = (Map<String, Object>) body.get("kakao_account");
+        String kakaoId = String.valueOf(userInfo.get("id"));
+        Map<String, Object> kakaoAccount = (Map<String, Object>) userInfo.get("kakao_account");
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
 
-        String email = kakaoAccount.get("email") != null ? kakaoAccount.get("email").toString() : kakaoId + "@kakao.com";
-        String nickname = (profile != null && profile.get("nickname") != null)
+        String email = kakaoAccount.get("email") != null
+                ? kakaoAccount.get("email").toString()
+                : kakaoId + "@kakao.com";
+
+        String nickname = profile != null && profile.get("nickname") != null
                 ? profile.get("nickname").toString()
                 : "KakaoUser";
 
-        // 사용자 조회/등록
+        // (3) DB 조회 or 회원가입
         User user = userRepository.findBySocialId(kakaoId).orElseGet(() -> {
             User newUser = new User();
             newUser.setSocialId(kakaoId);
@@ -73,11 +95,10 @@ public class KakaoAuthService {
             return userRepository.save(newUser);
         });
 
-        // JWT 토큰 생성
+        // (4) 자체 JWT 발급
         String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole());
         String refreshTokenValue = jwtTokenProvider.createRefreshToken(user.getEmail());
 
-        // Refresh Token 저장 (기존 토큰 삭제 후 갱신)
         refreshTokenRepository.deleteByUser(user);
 
         RefreshToken refreshToken = new RefreshToken();
@@ -87,8 +108,59 @@ public class KakaoAuthService {
 
         refreshTokenRepository.save(refreshToken);
 
-        System.out.println(" RefreshToken 저장 완료: " + refreshTokenValue);
-
         return new KakaoLoginResponse(accessToken, refreshTokenValue, email, nickname);
+    }
+
+    /**
+     * (A) code → Access Token 요청 (✅ 수정된 부분)
+     */
+    private Map<String, String> requestAccessToken(String code) {
+
+        // 1. 헤더 설정: Content-Type을 x-www-form-urlencoded로 명시
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // 2. 요청 본문(Body) 설정: HashMap 대신 MultiValueMap 사용
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+
+        // 💡 client-secret 추가 (필수 항목은 아니지만 보안 강화를 위해 사용)
+         params.add("client_secret", clientSecret);
+
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        // 3. HttpEntity 구성: 헤더와 본문을 담아 요청 객체 생성
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                tokenUri,
+                HttpMethod.POST,
+                request,
+                Map.class
+        );
+
+        return response.getBody();
+    }
+
+    /**
+     * (B) Access Token → 사용자 정보 요청
+     */
+    private Map<String, Object> requestUserInfo(String accessToken) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                userInfoUri,
+                HttpMethod.GET,
+                request,
+                Map.class
+        );
+
+        return response.getBody();
     }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/PostService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/PostService.java
@@ -82,11 +82,7 @@ public class PostService {
     }
 
     private User findOrCreateDummyUser() {
-        User user = userRepository.findByEmail(DUMMY_EMAIL);
-        if (user == null) {
-            user = User.createDummy();
-            return userRepository.save(user);
-        }
-        return user;
+        return userRepository.findByEmail(DUMMY_EMAIL)
+                .orElseGet(() -> userRepository.save(User.createDummy()));
     }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/PostService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/PostService.java
@@ -1,6 +1,7 @@
 package com.leets.backend.blog.service;
 
 import com.leets.backend.blog.dto.PostCreateRequest;
+import com.leets.backend.blog.dto.PostResponse;
 import com.leets.backend.blog.dto.PostUpdateRequest;
 import com.leets.backend.blog.entity.Post;
 import com.leets.backend.blog.entity.User;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,40 +28,52 @@ public class PostService {
         this.userRepository = userRepository;
     }
 
-    public List<Post> findAll() {
-        return postRepository.findAll();
+    // 게시물 목록 조회
+    public List<PostResponse> findAll() {
+        return postRepository.findAll()
+                .stream()
+                .map(PostResponse::from)
+                .collect(Collectors.toList());
     }
 
-    public Post findById(Long id) {
-        return postRepository.findById(id)
+    // 게시물 상세 조회
+    public PostResponse findById(Long id) {
+        Post post = postRepository.findById(id)
                 .orElseThrow(() -> new PostNotFoundException(id));
+        return PostResponse.from(post);
     }
 
+    // 게시물 생성
     @Transactional
-    public Post createPost(PostCreateRequest request) {
+    public PostResponse createPost(PostCreateRequest request) {
         User user = findOrCreateDummyUser();
         Post post = new Post(user, request.getTitle(), request.getContent());
-        return postRepository.save(post);
+        Post saved = postRepository.save(post);
+        return PostResponse.from(saved);
     }
 
+    // 게시물 수정
     @Transactional
-    public Post updatePost(Long id, PostUpdateRequest request) {
-        Post post = findById(id);
-        User dummyUser = findOrCreateDummyUser();
+    public PostResponse updatePost(Long id, PostUpdateRequest request) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new PostNotFoundException(id));
 
+        User dummyUser = findOrCreateDummyUser();
         if (!post.getUser().getUserId().equals(dummyUser.getUserId())) {
             throw new IllegalArgumentException("본인 게시글만 수정할 수 있습니다.");
         }
 
         post.updatePost(request.getTitle(), request.getContent());
-        return postRepository.save(post);
+        return PostResponse.from(postRepository.save(post));
     }
 
+    // 게시물 삭제
     @Transactional
     public void deletePost(Long id) {
-        Post post = findById(id);
-        User dummyUser = findOrCreateDummyUser();
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new PostNotFoundException(id));
 
+        User dummyUser = findOrCreateDummyUser();
         if (!post.getUser().getUserId().equals(dummyUser.getUserId())) {
             throw new IllegalArgumentException("본인 게시글만 삭제할 수 있습니다.");
         }

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/RefreshTokenService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/RefreshTokenService.java
@@ -1,4 +1,36 @@
+// src/main/java/com/leets/backend/blog/service/RefreshTokenService.java
 package com.leets.backend.blog.service;
 
+import com.leets.backend.blog.config.JwtTokenProvider;
+import com.leets.backend.blog.entity.RefreshToken;
+import com.leets.backend.blog.repository.RefreshTokenRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
 public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public RefreshTokenService(RefreshTokenRepository refreshTokenRepository,
+                               JwtTokenProvider jwtTokenProvider) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public String refreshAccessToken(String refreshTokenValue) {
+        Optional<RefreshToken> refreshTokenOpt = refreshTokenRepository.findByToken(refreshTokenValue);
+
+        if (refreshTokenOpt.isEmpty()) {
+            throw new RuntimeException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        RefreshToken refreshToken = refreshTokenOpt.get();
+        String userEmail = refreshToken.getUser().getEmail();
+
+        // 새로운 Access Token 생성
+        return jwtTokenProvider.generateToken(userEmail);
+    }
 }

--- a/blog_manage/src/main/java/com/leets/backend/blog/service/RefreshTokenService.java
+++ b/blog_manage/src/main/java/com/leets/backend/blog/service/RefreshTokenService.java
@@ -1,0 +1,4 @@
+package com.leets.backend.blog.service;
+
+public class RefreshTokenService {
+}

--- a/blog_manage/src/main/resources/application.yml
+++ b/blog_manage/src/main/resources/application.yml
@@ -25,3 +25,11 @@ jwt:
   secret: "ChangeThisToASuperLongRandomSecretKeyForJWT1234567890!@#ABCD"
   access-token-validity: 900000         # 15분 (단위: 밀리초)
   refresh-token-validity: 1209600000    # 14일 (단위: 밀리초)
+
+logging:
+  level:
+    root: INFO
+    org.springframework: DEBUG
+    org.hibernate.SQL: DEBUG
+    com.leets.backend.blog: DEBUG
+    org.springframework.security: DEBUG

--- a/blog_manage/src/main/resources/application.yml
+++ b/blog_manage/src/main/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     url: jdbc:mysql://localhost:3306/blogdb?serverTimezone=Asia/Seoul
     username: root
     password: 1234
+
   jpa:
     hibernate:
       ddl-auto: update  # 개발 단계에서는 update / 운영은 validate 권장
@@ -10,3 +11,17 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: your_email@gmail.com
+    password: your_app_password
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+
+jwt:
+  secret: "ChangeThisToASuperLongRandomSecretKeyForJWT1234567890!@#ABCD"
+  access-token-validity: 900000         # 15분 (단위: 밀리초)
+  refresh-token-validity: 1209600000    # 14일 (단위: 밀리초)

--- a/blog_manage/src/main/resources/application.yml
+++ b/blog_manage/src/main/resources/application.yml
@@ -21,10 +21,10 @@ spring:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
 
-jwt:
-  secret: "ChangeThisToASuperLongRandomSecretKeyForJWT1234567890!@#ABCD"
-  access-token-validity: 900000         # 15분 (단위: 밀리초)
-  refresh-token-validity: 1209600000    # 14일 (단위: 밀리초)
+  jwt:
+    secret: "ChangeThisToASuperLongRandomSecretKeyForJWT1234567890!@#ABCD"
+    access-token-validity: 900000         # 15분 (단위: 밀리초)
+    refresh-token-validity: 1209600000    # 14일 (단위: 밀리초)
 
 logging:
   level:
@@ -33,3 +33,11 @@ logging:
     org.hibernate.SQL: DEBUG
     com.leets.backend.blog: DEBUG
     org.springframework.security: DEBUG
+
+
+kakao:
+  client-id: 832cf040e50187a709811294587535ee
+  client-secret: "STyTYjHaJyNFryjqlbjSK6fdKmoLrEsj"
+  redirect-uri: http://localhost:8080/api/auth/kakao/callback
+  token-uri: https://kauth.kakao.com/oauth/token
+  user-info-uri: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
#122 
## 1. 어떤 이유로 코드를 변경했나요? 
- 기존 로그인 로직에서는 자체 회원가입만 지원하고, 소셜 로그인이 없었습니다.
-> 카카오 OAuth 2.0 인증을 도입하여 사용자가 별도 회원가입 없이 간편하게 로그인할 수 있도록 개선했습니다.
- 인증 로직 일부를 리팩토링하여 DB 조회 없이도 JwtAuthenticationFilter가 토큰만으로 `Authentication`을 생성할 수 있도록 개선했습니다.
- Refresh Token 저장 로직과 매핑 엔티티(`RefreshToken`, `User`)를 추가해, 로그인/재발급 과정에서 토큰이 DB에 안전하게 저장 및 검증되도록 했습니다.

## 2. 어떤 위험이나 장애를 발견했나요?
- 카카오 access_token 유효성 검증 문제
-> 카카오 API 호출 시 401 Unauthorized가 반복 발생
- Refresh Token 저장 누락 이슈
-> 로그인 성공 시 토큰이 발급되지만 DB에 저장되지 않음
- Refresh Token 불일치로 인한 500 오류
-> 클라이언트에서 전달한 refreshToken이 DB 저장값과 일치하지 않아 서버 에러 발생


## 3. 스크린 샷
<img width="1471" height="1461" alt="스크린샷 2025-11-25 233326" src="https://github.com/user-attachments/assets/fd76bafa-294e-4e7c-8b35-459c39e763fc" />

